### PR TITLE
Fixes #45 - Submodules config for first-time install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "packages/0xchat-core"]
 	path = packages/0xchat-core
-	url = https://github.com/0xchat-app//0xchat-core.git
+	url = ../0xchat-core.git
 [submodule "packages/nostr-dart"]
 	path = packages/nostr-dart
-	url = https://github.com/0xchat-app//nostr-dart.git
+	url = ../nostr-dart.git
 [submodule "packages/cashu-dart"]
 	path = packages/cashu-dart
-	url = https://github.com/0xchat-app/cashu-dart.git
+	url = ../cashu-dart.git
 [submodule "packages/nostr-mls-package"]
 	path = packages/nostr-mls-package
-	url = https://github.com/0xchat-app/nostr-mls-package.git
+	url = ../nostr-mls-package.git

--- a/ox_pub_get.sh
+++ b/ox_pub_get.sh
@@ -19,6 +19,8 @@ check(){
   fi
 }
 
+# Update submodules
+git submodule update --init --recursive --remote
 
 #checkout branch
 checkoutBranch(){


### PR DESCRIPTION
As per issue #45 , there is an issue installing git submodules on first-time setup. This is because the `ox_pub_get.sh` script depends on a `.git` file being set up in the submodule directory (i.e. `packages/0xchat-core`), pointing to the right repository url. Unfortunately, before submodules are sync'd, the repository url always points back to the `0xchat-app-main`, rendering the `git` commands in the install/update script useless.

A quick fix here was to precede the git fetch commands in the script with the following line: `git submodule update --init --recursive --remote`. This successfully first-time-installs the submodules along with their `.git` configuration, meaning the rest of the script works as expected. 

I also updated the `.gitmodules` file to 1) remove double-slashes that were present in two of the urls, and 2) use relative paths to respect `ssh` and `http` usage for the parent directory. Tested on my setup (using `ssh`) and submodules also cloned using `ssh`. For forking, adding a separate, non-main remote is recommended alongside the main one so that submodules can continue pointing to the main repository parent.