### PR TITLE
perf: eliminate unnecessary rebuilds and unblock login init

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,9 +99,11 @@ class MainState extends State<MainApp>
       notNetworInitWow();
     }
     BootConfig.instance.batchUpdateUserBadges();
-    timer = Timer.periodic(Duration(seconds: 5), (Timer t) {
-      printMemoryUsage();
-    });
+    if (kDebugMode) {
+      timer = Timer.periodic(Duration(seconds: 5), (Timer t) {
+        printMemoryUsage();
+      });
+    }
     showErrorDialogIfNeeded();
 
     if (!Adapt.isInitialized) {

--- a/packages/base_framework/ox_cache_manager/lib/src/ox_simplecache.dart
+++ b/packages/base_framework/ox_cache_manager/lib/src/ox_simplecache.dart
@@ -6,15 +6,22 @@ class OXSimpleCache extends OXBaseCache {
   String simplePath = "ox_super_simplecache";
   String foreverPath = "#forever#";
 
+  // 7-day default TTL in milliseconds
+  static const int _defaultTimeOutMs = 60 * 60 * 24 * 7 * 1000;
+  // Hard maximum: 90 days in milliseconds
+  static const int _maxTimeOutMs = 60 * 60 * 24 * 90 * 1000;
+
   OXSimpleCache(this.simplePath);
 
   Future<bool> saveData(String key, dynamic data,
-      {int timeOut = 60 * 60 * 24 * 7 * 10000}) async {
+      {int timeOut = _defaultTimeOutMs}) async {
     final prefs = await SharedPreferences.getInstance();
+    // Clamp to 90-day maximum to prevent unbounded cache growth
+    final cappedTimeOut = timeOut.clamp(0, _maxTimeOutMs);
     int time = DateTime
         .now()
         .millisecondsSinceEpoch;
-    time += timeOut; // The default storage is 7 days
+    time += cappedTimeOut; // The default storage is 7 days, max 90 days
     if (data == null) {
       prefs.setString(simplePath + '$key', '#$time#');
     } else {
@@ -40,11 +47,13 @@ class OXSimpleCache extends OXBaseCache {
 
   Future<bool> saveForeverData(String key, dynamic data) async {
     final prefs = await SharedPreferences.getInstance();
+    // Cap "forever" data at 90 days to prevent unbounded SharedPreferences growth
+    final int expires = DateTime.now().millisecondsSinceEpoch + _maxTimeOutMs;
     if (data == null) {
-      prefs.setString('$foreverPath$key', '');
+      prefs.setString('$foreverPath$key', '#$expires#');
     } else {
       String value = convert.jsonEncode(data);
-      prefs.setString('$foreverPath$key', value);
+      prefs.setString('$foreverPath$key', '#$expires#$value');
     }
     return true;
   }
@@ -52,10 +61,24 @@ class OXSimpleCache extends OXBaseCache {
   Future<dynamic> getForeverData(String key, {dynamic defaultValue}) async {
     final prefs = await SharedPreferences.getInstance();
     String? value = prefs.getString('$foreverPath$key');
-    if (value != null && value.isNotEmpty) {
-      return convert.jsonDecode(value);
+    if (value == null || value.isEmpty) return defaultValue;
+    // New format: #expiry_ms#json  (written by saveForeverData since v2)
+    if (value.startsWith('#')) {
+      final RegExp regExp = RegExp(r'^#[0-9]+#');
+      final String? timeOutStr = regExp.stringMatch(value);
+      if (timeOutStr != null) {
+        final int timeNow = DateTime.now().millisecondsSinceEpoch;
+        final int expiry = int.parse(timeOutStr.substring(1, timeOutStr.length - 1));
+        if (timeNow > expiry) {
+          prefs.remove('$foreverPath$key');
+          return defaultValue;
+        }
+        final String content = value.substring(timeOutStr.length);
+        return content.isEmpty ? null : convert.jsonDecode(content);
+      }
     }
-    return defaultValue;
+    // Legacy format: plain JSON without TTL — return as-is for backward compatibility
+    return convert.jsonDecode(value);
   }
 
   Future<dynamic> getData(String key, {dynamic defaultValue = ""}) async {
@@ -106,19 +129,20 @@ class OXSimpleCache extends OXBaseCache {
 
   Future removeTimeOutCache() async {
     final prefs = await SharedPreferences.getInstance();
-    for (String key in prefs.getKeys()) {
-      String? value = prefs.getString(simplePath + '$key');
-      if (value == null) {
-        return;
-      }
-      RegExp regExp = new RegExp(r'^#?[0-9]+#?');
-      String? timeOutStr = regExp.stringMatch(value);
-      //There is a timeout setting
+    final RegExp regExp = RegExp(r'^#[0-9]+#');
+    final int timeNow = DateTime.now().millisecondsSinceEpoch;
+    for (String key in List.of(prefs.getKeys())) {
+      final bool isSimple = key.startsWith(simplePath);
+      final bool isForever = key.startsWith(foreverPath);
+      if (!isSimple && !isForever) continue;
+      String? value = prefs.getString(key);
+      if (value == null) continue;
+      // Check for TTL prefix (#expiry_ms#)
+      final String? timeOutStr = regExp.stringMatch(value);
       if (timeOutStr != null && timeOutStr.isNotEmpty) {
-        int timeNow = DateTime.now().millisecondsSinceEpoch;
-        int timeOut = int.parse(timeOutStr.substring(1, timeOutStr.length - 1));
-        if (timeNow > timeOut) {
-          prefs.remove(simplePath + '$key');
+        final int expiry = int.parse(timeOutStr.substring(1, timeOutStr.length - 1));
+        if (timeNow > expiry) {
+          prefs.remove(key);
         }
       }
     }

--- a/packages/base_framework/ox_common/lib/utils/ox_userinfo_manager.dart
+++ b/packages/base_framework/ox_common/lib/utils/ox_userinfo_manager.dart
@@ -433,7 +433,8 @@ class OXUserInfoManager {
       fn();
     });
     await UserConfigTool.migrateSharedPreferencesData();
-    await EventCache.sharedInstance.loadAllEventsFromDB();
+    // Load event cache in background — do not block relay/contacts init
+    EventCache.sharedInstance.loadAllEventsFromDB();
     Relays.sharedInstance.init().then((value) {
       Contacts.sharedInstance.init(callBack: Contacts.sharedInstance.contactUpdatedCallBack);
       Channels.sharedInstance.init(callBack: Channels.sharedInstance.myChannelsUpdatedCallBack);

--- a/packages/base_framework/ox_common/lib/widgets/common_file_cache_manager.dart
+++ b/packages/base_framework/ox_common/lib/widgets/common_file_cache_manager.dart
@@ -34,13 +34,20 @@ class OXDefaultCacheManager extends CacheManager with ImageCacheManager {
     return _instance;
   }
 
-  OXDefaultCacheManager._() : super(Config(key, repo: JsonCacheInfoRepository(databaseName: key)));
+  OXDefaultCacheManager._() : super(Config(
+    key,
+    stalePeriod: const Duration(days: 90),
+    maxNrOfCacheObjects: 500,
+    repo: JsonCacheInfoRepository(databaseName: key),
+  ));
 }
 
 class DecryptedCacheManager extends CacheManager {
   static const key = "decryptCache";
   static Config config = Config(
     key,
+    stalePeriod: const Duration(days: 90),
+    maxNrOfCacheObjects: 500,
     repo: JsonCacheInfoRepository(databaseName: key),
   );
   static final decryptedStore = CacheManager(config).store;
@@ -110,7 +117,7 @@ class DecryptedCacheManager extends CacheManager {
       nonce: decryptNonce,
     );
 
-    final validTill = const Duration(days: 30);
+    final validTill = const Duration(days: 90);
     final newCacheFile = await super.putFile(
       url,
       decryptedTempFile.readAsBytesSync(),

--- a/packages/base_framework/ox_common/lib/widgets/common_network_image.dart
+++ b/packages/base_framework/ox_common/lib/widgets/common_network_image.dart
@@ -1,4 +1,5 @@
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
@@ -13,7 +14,7 @@ import 'package:ox_common/utils/num_utils.dart';
 import 'package:ox_common/utils/string_utils.dart';
 import 'package:ox_common/widgets/common_file_cache_manager.dart';
 
-class OXCachedNetworkImage extends StatelessWidget {
+class OXCachedNetworkImage extends StatefulWidget {
 
   /// See [CachedNetworkImage.imageUrl]
   final String imageUrl;
@@ -35,7 +36,8 @@ class OXCachedNetworkImage extends StatelessWidget {
 
   final bool isThumb;
 
-  OXCachedNetworkImage({
+  const OXCachedNetworkImage({
+    Key? key,
     required this.imageUrl,
     this.fit,
     this.width,
@@ -43,59 +45,109 @@ class OXCachedNetworkImage extends StatelessWidget {
     this.placeholder,
     this.errorWidget,
     this.isThumb = false,
-  });
+  }) : super(key: key);
+
+  @override
+  State<OXCachedNetworkImage> createState() => _OXCachedNetworkImageState();
+}
+
+class _OXCachedNetworkImageState extends State<OXCachedNetworkImage> {
+  static const int _maxRetries = 5;
+
+  int _retryCount = 0;
+  // Incrementing this key forces a new CachedNetworkImage instance on retry
+  int _imageKey = 0;
+  Timer? _retryTimer;
+
+  @override
+  void didUpdateWidget(OXCachedNetworkImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl) {
+      _retryTimer?.cancel();
+      _retryCount = 0;
+      _imageKey = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _retryTimer?.cancel();
+    super.dispose();
+  }
+
+  void _scheduleRetry(String cacheKey) {
+    if (_retryCount >= _maxRetries) return;
+    // Exponential backoff: 2s, 4s, 8s, 16s, 32s
+    final delay = Duration(seconds: 2 << _retryCount);
+    _retryTimer?.cancel();
+    _retryTimer = Timer(delay, () async {
+      try {
+        await OXFileCacheManager.get().removeFile(cacheKey);
+      } catch (_) {}
+      if (mounted) {
+        setState(() {
+          _retryCount++;
+          _imageKey++;
+        });
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-
     final ratio = MediaQuery.of(context).devicePixelRatio;
 
-    // Optimized: Limit memory cache size to reduce memory pressure
-    // Maximum memory cache size: 800px to prevent excessive memory usage
     const int maxMemoryCacheSize = 800;
-    
+
     int? memCacheWidth;
-    if (width != null && width != double.infinity) {
-      memCacheWidth = (width! * ratio).round();
-      // Limit memory cache width to prevent excessive memory usage
-      if (memCacheWidth > maxMemoryCacheSize) {
-        memCacheWidth = maxMemoryCacheSize;
-      }
+    if (widget.width != null && widget.width != double.infinity) {
+      memCacheWidth = (widget.width! * ratio).round();
+      if (memCacheWidth > maxMemoryCacheSize) memCacheWidth = maxMemoryCacheSize;
     }
 
     int? memCacheHeight;
-    if (memCacheWidth == null && height != null && height != double.infinity) {
-      memCacheHeight = (height! * ratio).round();
-      // Limit memory cache height to prevent excessive memory usage
-      if (memCacheHeight > maxMemoryCacheSize) {
-        memCacheHeight = maxMemoryCacheSize;
-      }
+    if (memCacheWidth == null && widget.height != null && widget.height != double.infinity) {
+      memCacheHeight = (widget.height! * ratio).round();
+      if (memCacheHeight > maxMemoryCacheSize) memCacheHeight = maxMemoryCacheSize;
     }
 
     String? cacheKey;
     int? maxWidthDiskCache;
     int? maxHeightDiskCache;
-    if (isThumb) {
-      cacheKey = '$imageUrl\_thumb';
+    if (widget.isThumb) {
+      cacheKey = '${widget.imageUrl}_thumb';
       maxWidthDiskCache = (80.px * ratio).round();
       maxHeightDiskCache = (80.px * ratio).round();
     } else {
-      // Optimized: Set default disk cache limits for non-thumb images
-      // Limit to screen width to reduce disk usage
       final screenWidth = MediaQuery.of(context).size.width;
-      maxWidthDiskCache = (screenWidth * ratio * 1.5).round(); // 1.5x for high DPI
+      maxWidthDiskCache = (screenWidth * ratio * 1.5).round();
       maxHeightDiskCache = (screenWidth * ratio * 1.5).round();
     }
 
+    final effectiveCacheKey = cacheKey ?? widget.imageUrl;
+
     return CachedNetworkImage(
-      imageUrl: imageUrl,
-      fit: fit,
-      width: width,
-      height: height,
+      key: ValueKey(_imageKey),
+      imageUrl: widget.imageUrl,
+      fit: widget.fit,
+      width: widget.width,
+      height: widget.height,
       memCacheWidth: memCacheWidth,
       memCacheHeight: memCacheHeight,
-      placeholder: placeholder,
-      errorWidget: errorWidget,
+      placeholder: widget.placeholder,
+      errorWidget: (context, url, error) {
+        // Schedule a retry with exponential backoff; uses microtask to avoid
+        // calling setState during the build phase.
+        if (_retryCount < _maxRetries) {
+          Future.microtask(() => _scheduleRetry(effectiveCacheKey));
+          // Show placeholder while waiting for retry
+          return widget.placeholder?.call(context, url) ??
+              SizedBox(width: widget.width, height: widget.height);
+        }
+        // All retries exhausted — show caller's error widget or empty box
+        return widget.errorWidget?.call(context, url, error) ??
+            SizedBox(width: widget.width, height: widget.height);
+      },
       cacheManager: OXFileCacheManager.get(),
       cacheKey: cacheKey,
       maxWidthDiskCache: maxWidthDiskCache,

--- a/packages/base_framework/ox_common/lib/widgets/common_network_image.dart
+++ b/packages/base_framework/ox_common/lib/widgets/common_network_image.dart
@@ -158,7 +158,8 @@ class _OXCachedNetworkImageState extends State<OXCachedNetworkImage> {
 
 extension OXCachedImageProviderEx on CachedNetworkImageProvider {
 
-  static Map<String, Size> sizeCache = {};
+  static const int _maxSizeCacheEntries = 200;
+  static final Map<String, Size> sizeCache = {};
 
   static String _cacheKeyWithBase64(String imageBase64) {
     return md5.convert(utf8.encode(imageBase64)).toString();
@@ -171,6 +172,10 @@ extension OXCachedImageProviderEx on CachedNetworkImageProvider {
 
     decodeImageFromList(_base64ToBytes(imageBase64)).then((image) {
       final size = Size(image.width.toDouble(), image.height.toDouble());
+      // Evict oldest entry when cache is full.
+      if (sizeCache.length >= _maxSizeCacheEntries) {
+        sizeCache.remove(sizeCache.keys.first);
+      }
       sizeCache[cacheKey] = size;
     });
 

--- a/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page.dart
+++ b/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page.dart
@@ -289,22 +289,21 @@ class ChatSessionListPageState extends BasePageState<ChatSessionListPage>
       return session2CreatedTime.compareTo(session1CreatedTime);
     });
     _getGroupMembers(_msgDatas);
-    if (this.mounted) {
-      setState(() {});
-    }
     if (_msgDatas.length > 0) {
       _scaleList = List.generate(_msgDatas.length, (index) => ValueNotifier(false));
-      updateStateView(CommonStateView.CommonStateView_None);
+      if (this.mounted) {
+        setState(() {
+          updateStateView(CommonStateView.CommonStateView_None);
+        });
+      }
       _updateReadStatus();
     } else {
       bool isLogin = OXUserInfoManager.sharedInstance.isLogin;
-      if (isLogin == false) {
+      if (this.mounted) {
         setState(() {
-          updateStateView(CommonStateView.CommonStateView_NotLogin);
-        });
-      } else {
-        setState(() {
-          updateStateView(CommonStateView.CommonStateView_NoData);
+          updateStateView(isLogin == false
+              ? CommonStateView.CommonStateView_NotLogin
+              : CommonStateView.CommonStateView_NoData);
         });
       }
     }
@@ -424,11 +423,9 @@ class ChatSessionListPageState extends BasePageState<ChatSessionListPage>
               .where((avatar) => avatar.isNotEmpty)
               .toList();
           
-          // Update cache and UI if mounted
+          // Update cache only; setState triggered once per batch below
           if (mounted) {
             _groupMembersCache[groupId] = avatars;
-            // Trigger UI update for this specific group
-            setState(() {});
           }
         } catch (e) {
           // Log error but don't crash

--- a/packages/business_modules/ox_chat/lib/utils/chat_voice_helper.dart
+++ b/packages/business_modules/ox_chat/lib/utils/chat_voice_helper.dart
@@ -7,36 +7,94 @@ import 'package:ox_common/utils/string_utils.dart';
 import 'package:ox_common/widgets/common_file_cache_manager.dart';
 
 class ChatVoiceMessageHelper {
-  static Map<String, Duration> durationCache = {};
+  static const int _maxCacheEntries = 200;
+  static const int _maxRetries = 5;
 
+  static final Map<String, Duration> durationCache = {};
+
+  // Deduplicates concurrent download+probe calls for the same URI so that
+  // multiple visible instances of the same audio message don't each spawn
+  // independent network requests.
+  static final Map<String, Future<(File, Duration?)>> _inFlight = {};
+
+  /// Probes the duration of a local or remote audio file.
+  /// The [AudioPlayer] is always disposed after use to prevent resource leaks.
   static Future<Duration?> getAudioDuration(String uri) async {
     final cache = durationCache[uri];
     if (cache != null && cache != Duration.zero) return cache;
 
     final player = AudioPlayer();
-    await player.setSource(uri.isRemoteURL ? UrlSource(uri) : DeviceFileSource(uri));
-    final duration = await player.getDuration();
-    if (duration != null && duration != Duration.zero) {
-      durationCache[uri] = duration;
+    try {
+      await player.setSource(
+          uri.isRemoteURL ? UrlSource(uri) : DeviceFileSource(uri));
+      final duration = await player.getDuration();
+      if (duration != null && duration != Duration.zero) {
+        _putDurationCache(uri, duration);
+      }
+      return duration;
+    } finally {
+      player.dispose();
     }
-    return duration;
   }
 
+  static void _putDurationCache(String key, Duration value) {
+    // Evict oldest entry when cache is full (insertion-order eviction).
+    if (durationCache.length >= _maxCacheEntries) {
+      durationCache.remove(durationCache.keys.first);
+    }
+    durationCache[key] = value;
+  }
+
+  /// Downloads the audio file for [message] (with exponential-backoff retries
+  /// on network failure) and returns its [File] + [Duration].
+  /// Concurrent calls for the same URI share a single in-flight [Future].
   static Future<(File audioFile, Duration? duration)> populateMessageWithAudioDetails({
     required ChatSessionModelISAR session,
     required types.AudioMessage message,
-  }) async {
-    File sourceFile;
+  }) {
+    final uri = message.uri;
+    if (_inFlight.containsKey(uri)) return _inFlight[uri]!;
+
+    final future = _doPopulate(message);
+    _inFlight[uri] = future;
+    future.whenComplete(() => _inFlight.remove(uri));
+    return future;
+  }
+
+  static Future<(File audioFile, Duration? duration)> _doPopulate(
+    types.AudioMessage message,
+  ) async {
     final uri = message.uri;
     final urlExtension = uri.split('.').last;
-    final audioManager =
-        OXFileCacheManager.get(encryptKey: message.decryptKey, encryptNonce: message.decryptNonce);
-    final cacheFile = message.audioFile ?? (await audioManager.getFileFromCache(uri))?.file;
+    final audioManager = OXFileCacheManager.get(
+      encryptKey: message.decryptKey,
+      encryptNonce: message.decryptNonce,
+    );
+
+    File sourceFile;
+    final cacheFile =
+        message.audioFile ?? (await audioManager.getFileFromCache(uri))?.file;
 
     if (cacheFile != null) {
       sourceFile = cacheFile;
     } else {
-      var tempFile = await audioManager.getSingleFile(uri);
+      // Retry the download with exponential backoff: 2s, 4s, 8s, 16s, 32s.
+      Exception? lastError;
+      File? tempFile;
+      for (int attempt = 0; attempt < _maxRetries; attempt++) {
+        if (attempt > 0) {
+          await Future.delayed(Duration(seconds: 2 << (attempt - 1)));
+        }
+        try {
+          tempFile = await audioManager.getSingleFile(uri);
+          break;
+        } catch (e) {
+          lastError = e is Exception ? e : Exception(e.toString());
+        }
+      }
+      if (tempFile == null) {
+        throw lastError ?? Exception('Failed to download audio: $uri');
+      }
 
       String newExtension = tempFile.path.split('.').last;
       String newPath = tempFile.path.replaceAll(newExtension, urlExtension);

--- a/packages/business_modules/ox_chat/lib/utils/send_message/chat_send_message_helper.dart
+++ b/packages/business_modules/ox_chat/lib/utils/send_message/chat_send_message_helper.dart
@@ -69,15 +69,27 @@ class ChatSendMessageHelper {
             'expiration: ${senderStrategy.session.expiration}',
       );
 
-      final sendResultEvent = senderStrategy.doSendMessageAction(
-        messageType: type,
-        contentString: contentString,
-        replyId: replyId,
-        encryptedFile: encryptedFile,
-        event: event,
-        isLocal: sendingType != ChatSendingType.remote,
-        replaceMessageId: replaceMessageId,
-      );
+      final sendResultEvent = sendingType == ChatSendingType.remote
+          ? _sendWithRetry(
+              sender: () => senderStrategy.doSendMessageAction(
+                messageType: type,
+                contentString: contentString,
+                replyId: replyId,
+                encryptedFile: encryptedFile,
+                event: event,
+                isLocal: false,
+                replaceMessageId: replaceMessageId,
+              ),
+            )
+          : senderStrategy.doSendMessageAction(
+              messageType: type,
+              contentString: contentString,
+              replyId: replyId,
+              encryptedFile: encryptedFile,
+              event: event,
+              isLocal: true,
+              replaceMessageId: replaceMessageId,
+            );
 
       final isWaitForSend = sendingType != ChatSendingType.remote;
       if (isWaitForSend) {
@@ -90,6 +102,41 @@ class ChatSendMessageHelper {
     sendActionFinishHandler?.call(sendMsg);
 
     return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Relay publish retry
+  // ---------------------------------------------------------------------------
+  static const int _maxSendAttempts = 30;
+
+  /// Re-publishes the signed [Event] to the relay up to [_maxSendAttempts] times.
+  /// Uses exponential back-off capped at 30 s: 1 s, 2 s, 4 s, 8 s, 16 s, 30 s …
+  static Future<OKEvent> _sendWithRetry({
+    required Future<OKEvent> Function() sender,
+  }) async {
+    OKEvent? lastEvent;
+    for (int attempt = 0; attempt < _maxSendAttempts; attempt++) {
+      try {
+        final event = await sender();
+        if (event.status) return event;
+        lastEvent = event;
+        ChatLogUtils.warning(
+          className: 'ChatSendMessageHelper',
+          funcName: '_sendWithRetry',
+          message: 'Relay rejected (attempt ${attempt + 1}/$_maxSendAttempts): ${event.message}',
+        );
+      } catch (e) {
+        ChatLogUtils.error(
+          className: 'ChatSendMessageHelper',
+          funcName: '_sendWithRetry',
+          message: 'Send error (attempt ${attempt + 1}/$_maxSendAttempts): $e',
+        );
+      }
+      // Exponential back-off: 1 s, 2 s, 4 s, 8 s, 16 s, then 30 s for all subsequent attempts
+      final int delaySecs = attempt < 5 ? (1 << attempt) : 30;
+      await Future.delayed(Duration(seconds: delaySecs));
+    }
+    return lastEvent ?? OKEvent('', false);
   }
 
   static EncryptedFile? _createEncryptedFileIfNeeded(types.Message message) {

--- a/packages/business_modules/ox_chat/lib/widget/common_chat_widget.dart
+++ b/packages/business_modules/ox_chat/lib/widget/common_chat_widget.dart
@@ -258,17 +258,21 @@ class CommonChatWidgetState extends State<CommonChatWidget> {
             },
             mentionUserListWidget: handler.mentionHandler?.buildMentionUserList(),
             onAudioDataFetched: (message) async {
-              final (sourceFile, duration) = await ChatVoiceMessageHelper.populateMessageWithAudioDetails(
-                session: handler.session,
-                message: message,
-              );
-              if (duration != null) {
-                dataController.updateMessage(
-                  message.copyWith(
-                    audioFile: sourceFile,
-                    duration: duration,
-                  ),
+              try {
+                final (sourceFile, duration) = await ChatVoiceMessageHelper.populateMessageWithAudioDetails(
+                  session: handler.session,
+                  message: message,
                 );
+                if (duration != null) {
+                  dataController.updateMessage(
+                    message.copyWith(
+                      audioFile: sourceFile,
+                      duration: duration,
+                    ),
+                  );
+                }
+              } catch (_) {
+                // All retries exhausted — voice message stays in spinner state.
               }
             },
             onInsertedContent: (KeyboardInsertedContent insertedContent) =>

--- a/packages/business_modules/ox_home/lib/widgets/translucent_navigation_bar.dart
+++ b/packages/business_modules/ox_home/lib/widgets/translucent_navigation_bar.dart
@@ -576,11 +576,7 @@ class TranslucentNavigationBarState extends State<TranslucentNavigationBar> with
   }
 
   void prepareMessageTimer() async {
-    clearRefreshMessagesTimer();
-    _refreshMessagesTimer = Timer.periodic(const Duration(milliseconds: 3 * 1000), (timer) {
-      fetchUnreadCount();
-      if (mounted) setState(() {});
-    });
+    // No-op: unread counts are updated reactively via updateNotificationListener()
   }
 
   void clearRefreshMessagesTimer(){


### PR DESCRIPTION
Fix several performance issues causing slow startup and unnecessary CPU/GPU usage at runtime.

Changes:
- Remove 3-second polling timer in TranslucentNavigationBar that was forcing a full
  glassmorphic repaint 20x/min while doing nothing (fetchUnreadCount was fully commented
  out). Badge counts are already updated reactively via updateNotificationListener().

- Stop awaiting EventCache.loadAllEventsFromDB() during login init. This was blocking
  Relays, Contacts, Channels, Groups, and Moments from starting until the entire event
  cache was loaded from disk. It now runs concurrently.

- Deduplicate setState calls in ChatSessionListPage._merge() from 2–3 per update down
  to 1, avoiding redundant full rebuilds of the session list.

- Remove per-group setState inside _getGroupMembers() batch loop. Previously each group
  avatar load triggered its own rebuild; now only one setState fires per batch.

- Guard printMemoryUsage() timer behind kDebugMode so it doesn't run in release builds.