### PR TITLE
fix: block HTTP/WS connections when Tor proxy is configured but not r…

### DIFF
--- a/lib/http_overrides.dart
+++ b/lib/http_overrides.dart
@@ -24,8 +24,14 @@ class OXHttpOverrides extends HttpOverrides {
     final settings = Config.sharedInstance.getProxy();
     final shouldUseTor = settings.turnOnTor || TorNetworkHelper.shouldUseTor(uri.toString());
     if (shouldUseTor) {
+      final torProxy = getTorProxy(context);
+      if (torProxy == null) {
+        // Tor is configured but not running — block the connection rather than
+        // silently falling back to a direct connection, which would leak traffic.
+        throw Exception('Tor proxy is enabled but not available');
+      }
       LogUtil.d('[OXHttpOverrides] Using Tor proxy');
-      return getTorProxy(context);
+      return torProxy;
     } else if (settings.turnOnProxy) {
       if (settings.useSystemProxy) {
         LogUtil.d('[OXHttpOverrides] Using system proxy');


### PR DESCRIPTION
…unning

When the user enables "Use Tor Network" in settings but the Tor service has not bootstrapped (e.g. Tor failed to start, or is still initialising), getProxySetting() previously returned null and silently fell back to a direct connection, leaking traffic. Now it throws an exception so the connection fails loudly instead of bypassing the configured proxy.

Fixes #58