### PR TITLE
perf(ox_chat): reuse stable per-row keys in chat session list

### DIFF
--- a/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page.dart
+++ b/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page.dart
@@ -67,6 +67,7 @@ class ChatSessionListPageState extends BasePageState<ChatSessionListPage>
   List<ChatSessionModelISAR> _msgDatas = []; // Message List
   int _allUnreadCount = 0;
   List<ValueNotifier<bool>> _scaleList = [];
+  List<GlobalKey> _itemKeys = [];
   Map<String, bool> _muteCache = {};
   Map<String, List<String>> _groupMembersCache = {};
   bool _isLogin = false;
@@ -271,6 +272,7 @@ class ChatSessionListPageState extends BasePageState<ChatSessionListPage>
   void _merge() {
     _msgDatas.clear();
     _scaleList.clear();
+    _itemKeys.clear();
     _isLogin = OXUserInfoManager.sharedInstance.isLogin;
     if (!_isLogin) {
       if (this.mounted) {
@@ -294,6 +296,7 @@ class ChatSessionListPageState extends BasePageState<ChatSessionListPage>
     }
     if (_msgDatas.length > 0) {
       _scaleList = List.generate(_msgDatas.length, (index) => ValueNotifier(false));
+      _itemKeys = List.generate(_msgDatas.length, (index) => GlobalKey());
       updateStateView(CommonStateView.CommonStateView_None);
       _updateReadStatus();
     } else {

--- a/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page_ui.dart
+++ b/packages/business_modules/ox_chat/lib/page/session/chat_session_list_page_ui.dart
@@ -112,10 +112,10 @@ extension ChatSessionListPageUI on ChatSessionListPageState{
   }
 
   Widget _buildListViewItem(context, int index) {
-    if(index >= _msgDatas.length) return SizedBox();
+    if(index >= _msgDatas.length || index >= _itemKeys.length) return SizedBox();
     ChatSessionModelISAR item = _msgDatas[index];
     bool isMuteCurrent = ChatSessionUtils.getChatMute(item);
-    GlobalKey tempKey = GlobalKey(debugLabel: index.toString());
+    final GlobalKey tempKey = _itemKeys[index];
     return GestureDetector(
       onHorizontalDragDown: (details) {
         _dismissSlidable();


### PR DESCRIPTION
Allocate one GlobalKey per row once in _merge (_itemKeys) instead of creating a new GlobalKey on every _buildListViewItem call. Recreating the key each build forces Element/State re-association while scrolling, which contributes to scroll jank. Also guards the index against _itemKeys.length.