### PR TITLE
ci: package Android and desktop builds, and fix what blocked them

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -14,7 +14,9 @@ outputs:
     description: Full version from pubspec.yaml, e.g. 1.3.5+69.
     value: ${{ steps.pubspec.outputs.version }}
   version_name:
-    description: Version without the build number, e.g. 1.3.5.
+    description: >-
+      Version used to name artifacts: taken from the tag on a tag build,
+      otherwise from pubspec.yaml.
     value: ${{ steps.pubspec.outputs.version_name }}
 
 runs:
@@ -53,11 +55,22 @@ runs:
       shell: bash
       run: flutter pub get
 
-    - name: Read version from pubspec.yaml
+    - name: Resolve build version
       id: pubspec
       shell: bash
       run: |
-        version=$(awk '/^version:/ {print $2; exit}' pubspec.yaml)
-        echo "version=$version" >> "$GITHUB_OUTPUT"
-        echo "version_name=${version%%+*}" >> "$GITHUB_OUTPUT"
-        echo "Building 0xchat $version"
+        pubspec_version=$(awk '/^version:/ {print $2; exit}' pubspec.yaml)
+        version_name="${pubspec_version%%+*}"
+
+        # On a tag build the tag is the release identity. pubspec.yaml has read
+        # 1.3.5+69 since well before the v1.4.x/v1.5.x tags, so naming files
+        # after it would label a v1.5.5-release build "1.3.5".
+        # v1.5.5-release -> 1.5.5, v1.5.3-release-desktop -> 1.5.3
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+          tag_version="${GITHUB_REF_NAME#v}"
+          version_name="${tag_version%%-release*}"
+        fi
+
+        echo "version=$pubspec_version" >> "$GITHUB_OUTPUT"
+        echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+        echo "Packaging 0xchat as $version_name (pubspec.yaml declares $pubspec_version)"

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,63 @@
+name: Setup Flutter
+description: >-
+  Initialise the submodules the app actually needs, install the pinned Flutter
+  SDK, resolve pub dependencies and expose the version from pubspec.yaml.
+
+inputs:
+  flutter-version:
+    description: Flutter SDK version to install (must match README / Dockerfile).
+    required: false
+    default: '3.29.3'
+
+outputs:
+  version:
+    description: Full version from pubspec.yaml, e.g. 1.3.5+69.
+    value: ${{ steps.pubspec.outputs.version }}
+  version_name:
+    description: Version without the build number, e.g. 1.3.5.
+    value: ${{ steps.pubspec.outputs.version_name }}
+
+runs:
+  using: composite
+  steps:
+    # Only nostr-dart and cashu-dart are referenced by path dependencies.
+    # nostr-mls-package is intentionally skipped: it is commented out in
+    # pubspec.yaml / 0xchat-core, so checking it out would only cost time.
+    - name: Init required submodules
+      shell: bash
+      run: git submodule update --init packages/nostr-dart packages/cashu-dart
+
+    # The `tor` dependency builds its native library through cargokit, on every
+    # platform. cargokit installs the toolchain and targets it needs by itself,
+    # but only if rustup is already on PATH. All current GitHub runner images
+    # ship it; this is the fallback, mirroring the repo Dockerfile.
+    - name: Ensure Rust toolchain
+      shell: bash
+      run: |
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.cargo/bin:$PATH"
+        fi
+        rustup --version
+        cargo --version
+
+    - name: Install Flutter ${{ inputs.flutter-version }}
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: ${{ inputs.flutter-version }}
+        channel: stable
+        cache: true
+
+    - name: Resolve dependencies
+      shell: bash
+      run: flutter pub get
+
+    - name: Read version from pubspec.yaml
+      id: pubspec
+      shell: bash
+      run: |
+        version=$(awk '/^version:/ {print $2; exit}' pubspec.yaml)
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "version_name=${version%%+*}" >> "$GITHUB_OUTPUT"
+        echo "Building 0xchat $version"

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -22,6 +22,16 @@ outputs:
 runs:
   using: composite
   steps:
+    # The url_launcher_linux override pulls all of flutter/packages, whose
+    # deepest paths (google_maps_flutter, pigeon) exceed the 260-character
+    # limit, so `flutter pub get` dies with "Filename too long" on Windows.
+    # The override cannot be scoped to Linux - pub applies dependency_overrides
+    # on every platform - so widen the limit instead.
+    - name: Enable long paths
+      if: runner.os == 'Windows'
+      shell: bash
+      run: git config --global core.longpaths true
+
     # Only nostr-dart and cashu-dart are referenced by path dependencies.
     # nostr-mls-package is intentionally skipped: it is commented out in
     # pubspec.yaml / 0xchat-core, so checking it out would only cost time.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,11 @@ jobs:
   windows:
     name: Windows (x64)
     if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows' || github.ref_name == 'ci/build-and-package-workflows'
-    runs-on: windows-latest
+    # Pinned, not windows-latest: that label now resolves to the
+    # windows-2025-vs2026 image, and flutter_tools 3.29.3 maps only Visual
+    # Studio major 17 to a CMake generator, falling back to "Visual Studio 16
+    # 2019" for anything newer - a generator no current runner has.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ on:
   push:
     tags:
       - 'v*'
+    # TEMPORARY: verify the Windows job before this workflow reaches main,
+    # where workflow_dispatch would be available. Revert with the commit.
+    branches:
+      - 'ci/build-and-package-workflows'
 
 permissions:
   contents: read
@@ -181,7 +185,7 @@ jobs:
 
   windows:
     name: Windows (x64)
-    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows' || github.ref_name == 'ci/build-and-package-workflows'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,6 @@ on:
   push:
     tags:
       - 'v*'
-    # TEMPORARY: verify the Windows job before this workflow reaches main,
-    # where workflow_dispatch would be available. Revert with the commit.
-    branches:
-      - 'ci/build-and-package-workflows'
 
 permissions:
   contents: read
@@ -185,7 +181,7 @@ jobs:
 
   windows:
     name: Windows (x64)
-    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows' || github.ref_name == 'ci/build-and-package-workflows'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows'
     # Pinned, not windows-latest: that label now resolves to the
     # windows-2025-vs2026 image, and flutter_tools 3.29.3 maps only Visual
     # Studio major 17 to a CMake generator, falling back to "Visual Studio 16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,235 @@
+# Packages 0xchat for Android and the desktop platforms.
+#
+# Triggers
+#   - Manually (Actions -> Build & Package -> Run workflow), optionally for a
+#     single platform.
+#   - Automatically on a `v*` tag; in that case every artifact is also attached
+#     to a draft GitHub Release.
+#
+# Optional secrets (Android release signing). android/app/build.gradle attaches
+# no signingConfig to the release build type unless android/key.properties
+# exists, so WITHOUT these secrets the APK comes out completely unsigned and
+# cannot be installed on a device (verified locally with apksigner):
+#   ANDROID_KEYSTORE_BASE64  - `base64 -i my-release-key.jks` output
+#   ANDROID_KEYSTORE_PASSWORD
+#   ANDROID_KEY_ALIAS
+#   ANDROID_KEY_PASSWORD
+#
+# macOS artifacts are ad-hoc signed only (the Xcode project uses
+# CODE_SIGN_IDENTITY = "-"). Distributing outside of a "right click -> Open"
+# flow additionally needs a Developer ID certificate and notarisation.
+
+name: Build & Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build
+        type: choice
+        default: all
+        options:
+          - all
+          - android
+          - linux
+          - windows
+          - macos
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android (APK + AAB)
+    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'android'
+    runs-on: ubuntu-22.04
+    env:
+      KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # android/app/build.gradle compiles against Java 21.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # cargokit (used by the `tor` dependency) builds the native library with
+      # the exact NDK named by android.ndkVersion in android/app/build.gradle.
+      - name: Install Android NDK
+        run: |
+          sdk="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+          yes | "$sdk" --licenses > /dev/null 2>&1 || true
+          "$sdk" --install "ndk;27.0.12077973"
+
+      - id: setup
+        uses: ./.github/actions/setup-flutter
+
+      # android/app/build.gradle picks up android/key.properties when present.
+      - name: Configure release signing
+        if: env.KEYSTORE_BASE64 != ''
+        env:
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > android/app/release-keystore.jks
+          {
+            echo "storeFile=app/release-keystore.jks"
+            echo "storePassword=$STORE_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "keyPassword=$KEY_PASSWORD"
+          } > android/key.properties
+
+      - name: Warn when unsigned
+        if: env.KEYSTORE_BASE64 == ''
+        run: echo "::warning::No ANDROID_KEYSTORE_BASE64 secret - artifacts will be UNSIGNED and cannot be installed."
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Build App Bundle
+        run: flutter build appbundle --release
+
+      - name: Rename outputs
+        run: |
+          v="${{ steps.setup.outputs.version_name }}"
+          suffix=""
+          [ -z "$KEYSTORE_BASE64" ] && suffix="-unsigned"
+          mkdir -p dist
+          mv build/app/outputs/flutter-apk/app-release.apk "dist/oxchat-$v-android$suffix.apk"
+          mv build/app/outputs/bundle/release/app-release.aab "dist/oxchat-$v-android$suffix.aab"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android
+          path: dist/*
+          if-no-files-found: error
+
+  linux:
+    name: Linux (x64)
+    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'linux'
+    # 22.04 keeps the glibc requirement low for the produced bundle.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Mirrors the package list in the repo Dockerfile.
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            cmake \
+            ninja-build \
+            pkg-config \
+            file \
+            libgtk-3-dev \
+            libglu1-mesa \
+            libssl-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav
+
+      - id: setup
+        uses: ./.github/actions/setup-flutter
+
+      - name: Build
+        run: flutter build linux --release
+
+      - name: Package
+        run: |
+          v="${{ steps.setup.outputs.version_name }}"
+          mkdir -p dist
+          tar -czf "dist/oxchat-$v-linux-x64.tar.gz" -C build/linux/x64/release/bundle .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux
+          path: dist/*
+          if-no-files-found: error
+
+  windows:
+    name: Windows (x64)
+    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'windows'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./.github/actions/setup-flutter
+
+      - name: Build
+        run: flutter build windows --release
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $v = "${{ steps.setup.outputs.version_name }}"
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath "dist/oxchat-$v-windows-x64.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: dist/*
+          if-no-files-found: error
+
+  macos:
+    name: macOS (.app)
+    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./.github/actions/setup-flutter
+
+      # `flutter build macos` runs `pod install` itself.
+      - name: Build
+        run: flutter build macos --release
+
+      # The bundle is named after PRODUCT_NAME (0xchat.app), not the Flutter
+      # target, so resolve it rather than hardcoding the name.
+      - name: Package
+        run: |
+          v="${{ steps.setup.outputs.version_name }}"
+          app=$(find build/macos/Build/Products/Release -maxdepth 1 -name '*.app' | head -1)
+          test -n "$app" || { echo "no .app produced"; exit 1; }
+          mkdir -p dist
+          ditto -c -k --keepParent "$app" "dist/oxchat-$v-macos.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: Draft release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [android, linux, windows, macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,11 @@ jobs:
     env:
       KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
     steps:
+      # Full history: the versionCode below is the commit count, which a
+      # shallow clone would report as 1.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # android/app/build.gradle compiles against Java 21.
       - uses: actions/setup-java@v4
@@ -92,11 +96,27 @@ jobs:
         if: env.KEYSTORE_BASE64 == ''
         run: echo "::warning::No ANDROID_KEYSTORE_BASE64 secret - artifacts will be UNSIGNED and cannot be installed."
 
+      # pubspec.yaml has declared 1.3.5+69 since 2025-03-18, so left alone every
+      # release would ship versionCode 69 and Play would reject the upload as
+      # not incrementing. Stamp the tag version and use the commit count, which
+      # only ever grows.
+      - name: Resolve Android version
+        id: android_version
+        run: |
+          echo "name=${{ steps.setup.outputs.version_name }}" >> "$GITHUB_OUTPUT"
+          echo "code=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build APK
-        run: flutter build apk --release
+        run: |
+          flutter build apk --release \
+            --build-name "${{ steps.android_version.outputs.name }}" \
+            --build-number "${{ steps.android_version.outputs.code }}"
 
       - name: Build App Bundle
-        run: flutter build appbundle --release
+        run: |
+          flutter build appbundle --release \
+            --build-name "${{ steps.android_version.outputs.name }}" \
+            --build-number "${{ steps.android_version.outputs.code }}"
 
       - name: Rename outputs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   android:
     name: Android (APK + AAB)
-    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'android'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'android'
     runs-on: ubuntu-22.04
     env:
       KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -135,7 +135,7 @@ jobs:
 
   linux:
     name: Linux (x64)
-    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'linux'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'linux'
     # 22.04 keeps the glibc requirement low for the produced bundle.
     runs-on: ubuntu-22.04
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   windows:
     name: Windows (x64)
-    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'windows'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
 
   macos:
     name: macOS (.app)
-    if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos'
+    if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'macos'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,15 +12,12 @@ if (localPropertiesFile.exists()) {
   }
 }
 
+// Written to local.properties by the Flutter tool. They mirror pubspec.yaml
+// unless --build-name / --build-number are passed, which is how CI stamps a
+// release version onto the build. Null when Gradle is invoked directly, in
+// which case the pubspec values below are used.
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-  flutterVersionCode = '1'
-}
-
 def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-  flutterVersionName = '1.0'
-}
 
 android {
   namespace 'com.oxchat.nostr'
@@ -41,13 +38,15 @@ android {
   //disable resource file check
   def version = parsePubspecVersion()
   def versionParts = version.split("\\+")
+  def resolvedVersionCode = (flutterVersionCode ?: versionParts[1]) as Integer
+  def resolvedVersionName = flutterVersionName ?: versionParts[0]
   defaultConfig {
     applicationId "com.oxchat.nostr"
     minSdk 28
     targetSdk 35
     multiDexEnabled true
-    versionCode versionParts[1] as Integer
-    versionName versionParts[0]
+    versionCode resolvedVersionCode
+    versionName resolvedVersionName
 
     // Support for 16KB page sizes
     externalNativeBuild {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -249,7 +249,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>strike</string>

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -39,6 +39,14 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
+
+    # Some pods declare a deployment target below the 10.15 this app requires
+    # (flutter_inappwebview_macos ships 10.14). Newer Swift compilers turn the
+    # resulting availability mismatch into a hard error, so align every pod
+    # with the platform declared above.
+    target.build_configurations.each do |config|
+      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.15'
+    end
   end
   
 # Bitcode stripping configuration

--- a/packages/base_framework/ox_common/pubspec.yaml
+++ b/packages/base_framework/ox_common/pubspec.yaml
@@ -48,7 +48,10 @@ dependencies:
   image_gallery_saver_plus:
     git:
       url: https://github.com/ArmanKT/image_gallery_saver_plus.git
-      ref: master
+      # Pinned: upstream master raised its SDK floor to Dart >=3.9.2, which no
+      # longer resolves on the Flutter 3.29.3 (Dart 3.7.2) this project targets.
+      # This commit was the master tip from 2025-03-07 until that bump.
+      ref: 32cebada96d895d72239be8f8e2f4eb26c453256
   flutter_svg: ^2.0.4
   flutter_staggered_grid_view: ^0.6.1
   waterfall_flow: ^3.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.5+69
+version: 1.5.5+5943
 
 environment:
   sdk: ">=3.0.5 <4.0.0"


### PR DESCRIPTION
Adds CI to package Android and the desktop platforms, plus the fixes needed to make those builds work at all. Every platform was built and verified before this PR — details below.

## What this adds

`Build & Package`, one job per platform, sharing a composite action for setup (submodules, rustup, Flutter 3.29.3, version resolution).

- **Manual runs** — Actions → Build & Package → Run workflow, optionally for a single platform.
- **Tag runs** — pushing a `v*` tag builds all four platforms and attaches the artifacts to a **draft** release for review before publishing.

## Fixes that are independent of CI

These three are real bugs that affect anyone building the project, not just CI. They are separate commits and stand on their own:

- **`flutter pub get` was broken on any fresh checkout.** `image_gallery_saver_plus` tracked `ref: master`, and upstream raised its SDK floor to Dart >=3.9.2 on 2026-05-22. With the root `pubspec.lock` gitignored, every clean resolve pulled that tip and failed against the Flutter 3.29.3 this project targets. Pinned to `32cebada`, which was the master tip from 2025-03-07 until that bump — the code the project has been building against all along.
- **Android shipped `versionCode 69` on every release.** `build.gradle` read `flutter.versionCode`/`flutter.versionName` and then never used them, deriving the version from `pubspec.yaml` instead — so `--build-name`/`--build-number` were dead options. Play rejects an upload whose versionCode does not increase. CI now stamps the tag version and the commit count.
- **iOS `CFBundleVersion` was hardcoded to `1`.** App Store Connect rejects duplicate build numbers within a version. Now uses `$(FLUTTER_BUILD_NUMBER)`, matching what macOS already did.

Also: `macos/Podfile` now aligns every pod with the declared 10.15 deployment target (newer Swift compilers turn the `flutter_inappwebview_macos` availability mismatch into a hard error), and `pubspec.yaml` moves from the long-stale `1.3.5+69` to `1.5.5+5943`.

## Verification

| Platform | How |
|---|---|
| Android APK + AAB | Built locally; `aapt2` confirms `versionCode=5943 versionName=1.5.6` with overrides and `69`/`1.3.5` without |
| macOS | Built locally — `0xchat.app`, universal (x86_64 + arm64) |
| iOS | Built locally — `CFBundleVersion=5943`, `CFBundleShortVersionString=1.5.5` |
| Linux | Built in an `ubuntu:22.04` container using this workflow's exact apt list, from a clean source copy |
| Windows | Built on real CI — [run 31374310376](https://github.com/0xchat-app/0xchat-app-main/actions/runs/31374310376), 44.6 MB artifact |

Two things only the real Windows runner could surface:

- `flutter pub get` died with `Filename too long`. The `url_launcher_linux` override clones all of `flutter/packages`, whose `google_maps_flutter` and `pigeon` paths exceed 260 characters. `dependency_overrides` apply on every platform and cannot be scoped to Linux, so the job sets `core.longpaths`.
- CMake could not find Visual Studio. `windows-latest` now resolves to the `windows-2025-vs2026` image, and flutter_tools 3.29.3 maps only VS major 17 to a generator — anything newer falls back to `Visual Studio 16 2019`, which no current runner has. Pinned to `windows-2022`. **Moving off that pin means upgrading Flutter, not changing the label.**

Two commits in this branch are a temporary branch trigger and its revert; that was the only way to exercise the Windows job, since `workflow_dispatch` registers only for workflows already on the default branch. The workflow file reaching `main` is what makes manual runs available.

## Before the first release build

Android release signing needs four repository secrets: `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`. Without them `build.gradle` attaches no signingConfig, so the APK comes out **unsigned and uninstallable** — verified with `apksigner`. Those artifacts are named `-unsigned` and the job logs a warning rather than failing.

macOS artifacts are ad-hoc signed only; Developer ID and notarisation are still needed for distribution outside a right-click-Open flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
