### PR TITLE
fix: stop a failed account login from wiping the logged in account

### DIFF
--- a/packages/0xchat-core/lib/src/account/account+nip46.dart
+++ b/packages/0xchat-core/lib/src/account/account+nip46.dart
@@ -4,10 +4,24 @@ import 'dart:io';
 import 'package:nostr_core_dart/nostr.dart';
 import 'package:chatcore/chat-core.dart';
 
+/// How long to wait for a relay of the remote signer to become reachable.
+const Duration _nip46RelayConnectTimeout = Duration(seconds: 30);
+
+/// How long to wait for the remote signer to answer a command.
+const Duration _nip46CommandTimeout = Duration(seconds: 60);
+
+/// How long to wait once the signer replied with an `auth_url`, the user has to
+/// authorize the request in a browser before the real answer shows up.
+const Duration _nip46AuthTimeout = Duration(minutes: 3);
+
 extension AccountNIP46 on Account {
   Future<bool> _checkNIP46Pubkey(String pubkey) async {
     if (me == null || me?.remoteSignerURI == null) return false;
-    await connectToRemoteSigner(me!.remoteSignerURI!, true, pubkey);
+    OKEvent connectResult = await connectToRemoteSigner(me!.remoteSignerURI!, true, pubkey);
+    if (!connectResult.status) {
+      LogUtils.e(() => 'check NIP46 pubkey failed: ${connectResult.message}');
+      return false;
+    }
     String? getPubkey = await sendGetPubicKey();
     if (getPubkey == null || getPubkey != pubkey) return false;
     return true;
@@ -29,7 +43,11 @@ extension AccountNIP46 on Account {
   }
 
   Future<UserDBISAR?> _loginWithBunkerURI(String uri) async {
-    await connectToRemoteSigner(uri, false, '');
+    OKEvent connectResult = await connectToRemoteSigner(uri, false, '');
+    if (!connectResult.status) {
+      LogUtils.e(() => 'login with bunker URI failed: ${connectResult.message}');
+      return null;
+    }
     String? getPubkey = await sendGetPubicKey();
     if (getPubkey == null) return null;
     UserDBISAR? userDBISAR = await loginWithPubKey(getPubkey, SignerApplication.remoteSigner);
@@ -75,7 +93,7 @@ extension AccountNIP46 on Account {
 
   Future<String> getPublicKeyWithNostrConnectURI(String uri) async {
     nip46connectionStatusCallback?.call(NIP46ConnectionStatus.waitingForSigning);
-    Connect.sharedInstance.addConnectStatusListener((relay, status, relayKinds) async {
+    _replaceNIP46ConnectStatusListener((relay, status, relayKinds) async {
       if (status == 1 && tempRemoteConnection!.relays.contains(relay)) {
         updateNIP46Subscription(relay: relay, connection: tempRemoteConnection);
         for (var event in unsentNIP46EventQueue) {
@@ -90,7 +108,15 @@ extension AccountNIP46 on Account {
     Completer<NIP46CommandResult> completer = Completer<NIP46CommandResult>();
     String secret = tempRemoteConnection!.secret!;
     resultCompleters[secret] = completer;
-    await completer.future;
+    // The user has to approve the pairing in the signer, but the wait still
+    // has to end: without a deadline the caller spins forever.
+    _startNIP46CommandTimeout(secret, _nip46AuthTimeout);
+    NIP46CommandResult connectResult = await completer.future;
+    if (connectResult.error != null) {
+      LogUtils.e(() => 'nostr connect failed: ${connectResult.error}');
+      nip46connectionStatusCallback?.call(NIP46ConnectionStatus.disconnected);
+      return '';
+    }
     currentRemoteConnection = tempRemoteConnection;
     String? pubkey = await sendGetPubicKey();
     if (pubkey != null) {
@@ -122,13 +148,20 @@ extension AccountNIP46 on Account {
     };
   }
 
+  /// Connects to the remote signer described by [uri].
+  ///
+  /// The returned [OKEvent] tells whether the signer is usable, callers must
+  /// not keep talking to it when the status is false. Every wait in here is
+  /// bounded: a relay or a signer that never answers ends up as a failed
+  /// OKEvent instead of a future that never completes.
   Future<OKEvent> connectToRemoteSigner(String uri, bool autoLogin, String remotePubkey) async {
-    Completer<OKEvent> completer = Completer<OKEvent>();
     late RemoteSignerConnection remoteSignerConnection;
     if (uri.startsWith('bunker://')) {
       remoteSignerConnection = Nip46.parseBunkerUri(uri);
     } else if (uri.startsWith('nostrconnect://')) {
       remoteSignerConnection = Nip46.parseNostrConnectUri(uri);
+    } else {
+      return OKEvent(uri, false, 'unsupported remote signer URI');
     }
     currentRemoteConnection = remoteSignerConnection;
     currentRemoteConnection!.clientPrivkey = me?.clientPrivateKey;
@@ -143,21 +176,36 @@ extension AccountNIP46 on Account {
       currentRemoteConnection!.clientPubkey =
           Keychain(currentRemoteConnection!.clientPrivkey!).public;
     }
-    Connect.sharedInstance.addConnectStatusListener((relay, status, relayKinds) async {
-      if (status == 1 && remoteSignerConnection.relays.contains(relay)) {
-        nip46connectionStatusCallback?.call(NIP46ConnectionStatus.connected);
-        updateNIP46Subscription(relay: relay, connection: currentRemoteConnection);
-        if (!autoLogin) {
-          await sendConnect();
-        } else {
-          for (var event in unsentNIP46EventQueue) {
-            Connect.sharedInstance.sendEvent(event, toRelays: currentRemoteConnection!.relays);
-          }
-          unsentNIP46EventQueue.clear();
+    if (remoteSignerConnection.relays.isEmpty) {
+      return OKEvent(uri, false, 'the remote signer URI contains no relay');
+    }
+
+    Completer<String> relayConnected = Completer<String>();
+    void handleRelayConnected(String relay) {
+      nip46connectionStatusCallback?.call(NIP46ConnectionStatus.connected);
+      updateNIP46Subscription(relay: relay, connection: currentRemoteConnection);
+      if (autoLogin) {
+        for (var event in unsentNIP46EventQueue) {
+          Connect.sharedInstance.sendEvent(event, toRelays: currentRemoteConnection!.relays);
         }
-        if (!completer.isCompleted) completer.complete(OKEvent(uri, true, ''));
+        unsentNIP46EventQueue.clear();
       }
-      else if(status != 1 && remoteSignerConnection.relays.contains(relay)){
+      if (!relayConnected.isCompleted) {
+        relayConnected.complete(relay);
+      } else if (!autoLogin) {
+        // Reconnected after the initial handshake, re-announce this client.
+        sendConnect();
+      }
+    }
+
+    // Only one remote signer connection is active at a time, so drop the
+    // listener of the previous one instead of piling them up: a stale listener
+    // keeps talking to the signer of an account that is no longer logged in.
+    _replaceNIP46ConnectStatusListener((relay, status, relayKinds) async {
+      if (!remoteSignerConnection.relays.contains(relay)) return;
+      if (status == 1) {
+        handleRelayConnected(relay);
+      } else {
         // lost connection
         nip46connectionStatusCallback?.call(NIP46ConnectionStatus.disconnected);
       }
@@ -165,7 +213,84 @@ extension AccountNIP46 on Account {
 
     await Connect.sharedInstance
         .connectRelays(remoteSignerConnection.relays, relayKind: RelayKind.remoteSigner);
-    return completer.future;
+
+    // Connect.connect() returns without reporting a status change when the
+    // socket is already open, which is the common case when another account is
+    // logged in on the same relay. Nothing would ever complete the wait below.
+    if (!relayConnected.isCompleted) {
+      for (var relay in remoteSignerConnection.relays) {
+        if (Connect.sharedInstance.webSockets[relay]?.connectStatus == 1) {
+          handleRelayConnected(relay);
+          break;
+        }
+      }
+    }
+
+    String connectedRelay =
+        await relayConnected.future.timeout(_nip46RelayConnectTimeout, onTimeout: () => '');
+    if (connectedRelay.isEmpty) {
+      nip46connectionStatusCallback?.call(NIP46ConnectionStatus.disconnected);
+      return OKEvent(uri, false, 'timed out connecting to the remote signer relay');
+    }
+
+    if (!autoLogin) {
+      NIP46CommandResult result = await sendConnectCommand();
+      if (result.error != null) {
+        return OKEvent(uri, false, result.error!);
+      }
+      if (result.result != 'ack') {
+        // Not every signer answers the connect command with an ack, the real
+        // gate is whether it hands out the public key afterwards.
+        LogUtils.e(() => 'remote signer answered connect with ${result.result}');
+      }
+    }
+    return OKEvent(uri, true, '');
+  }
+
+  /// Drops the commands pending on the remote signer.
+  ///
+  /// Called on logout: the signer of the account that is going away will never
+  /// answer them, so they are failed right away instead of being left hanging
+  /// until their deadline, and no queued command is replayed to the signer of
+  /// whichever account is logged in next.
+  void resetNIP46State() {
+    for (var timer in nip46CommandTimers.values) {
+      timer.cancel();
+    }
+    nip46CommandTimers.clear();
+    for (var entry in resultCompleters.entries) {
+      if (!entry.value.isCompleted) {
+        entry.value.complete(NIP46CommandResult(id: entry.key, error: 'logged out'));
+      }
+    }
+    resultCompleters.clear();
+    unsentNIP46EventQueue.clear();
+  }
+
+  /// Registers [listener] as the only connection status listener of the remote
+  /// signer, removing the one registered by a previous connection.
+  void _replaceNIP46ConnectStatusListener(ConnectStatusCallBack listener) {
+    ConnectStatusCallBack? previous = nip46ConnectStatusListener;
+    if (previous != null) {
+      Connect.sharedInstance.removeConnectStatusListener(previous);
+    }
+    nip46ConnectStatusListener = listener;
+    Connect.sharedInstance.addConnectStatusListener(listener);
+  }
+
+  /// Fails the pending command [id] after [duration] so that a signer that
+  /// never answers surfaces an error instead of blocking its caller forever.
+  void _startNIP46CommandTimeout(String id, Duration duration, {void Function()? onTimeout}) {
+    nip46CommandTimers.remove(id)?.cancel();
+    nip46CommandTimers[id] = Timer(duration, () {
+      nip46CommandTimers.remove(id);
+      Completer<NIP46CommandResult>? completer = resultCompleters.remove(id);
+      if (completer == null || completer.isCompleted) return;
+      onTimeout?.call();
+      LogUtils.e(() => 'remote signer command $id timed out');
+      completer.complete(
+          NIP46CommandResult(id: id, error: 'the remote signer did not respond in time'));
+    });
   }
 
   Future<String?> sendGetPubicKey() async {
@@ -203,6 +328,11 @@ extension AccountNIP46 on Account {
           nip46commandResultCallback?.call(result);
           if (result.result == 'auth_url') {
             LogUtils.v(() => 'connect waiting for auth... ${result.toString()}');
+            // The real answer only arrives once the user authorized the request
+            // in a browser, so give the command a longer deadline.
+            if (resultCompleters.containsKey(result.id)) {
+              _startNIP46CommandTimeout(result.id, _nip46AuthTimeout);
+            }
             return;
           }
           String resultId = result.id;
@@ -211,6 +341,7 @@ extension AccountNIP46 on Account {
             resultId = result.result;
             connection.remotePubkey = event.pubkey;
           }
+          nip46CommandTimers.remove(resultId)?.cancel();
           Completer? completer = resultCompleters[resultId];
           if (completer != null && !completer.isCompleted) completer.complete(result);
           resultCompleters.remove(resultId);
@@ -225,6 +356,10 @@ extension AccountNIP46 on Account {
   Future<NIP46CommandResult> sendToRemoteSigner(Event event, String id) {
     Completer<NIP46CommandResult> completer = Completer<NIP46CommandResult>();
     resultCompleters[id] = completer;
+    _startNIP46CommandTimeout(id, _nip46CommandTimeout, onTimeout: () {
+      // Drop the event so a later connection does not replay a dead command.
+      unsentNIP46EventQueue.remove(event);
+    });
     bool hasConnected = false;
     for (var relay in currentRemoteConnection!.relays) {
       if (Connect.sharedInstance.webSockets[relay]?.connectStatus == 1) {
@@ -240,19 +375,22 @@ extension AccountNIP46 on Account {
     return completer.future;
   }
 
-  Future<bool> sendConnect() async {
+  Future<NIP46CommandResult> sendConnectCommand() async {
     NIP46Command command = NIP46Command.connect(currentRemoteConnection!.remotePubkey,
         currentRemoteConnection!.secret, SignerPermissionModel.defaultPermissionsForNIP46());
     var id = generate64RandomHexChars();
     Event event = await Nip46.encode(currentRemoteConnection!.remotePubkey, id, command,
         currentRemoteConnection!.clientPubkey!, currentRemoteConnection!.clientPrivkey!);
-    NIP46CommandResult result = await sendToRemoteSigner(event, id);
+    return await sendToRemoteSigner(event, id);
+  }
 
+  Future<bool> sendConnect() async {
+    NIP46CommandResult result = await sendConnectCommand();
     if (result.result != 'ack') {
-      print('sendConnect connected false');
+      LogUtils.e(() => 'sendConnect connected false: ${result.error ?? result.result}');
       return false;
     }
-    print('sendConnect connected success');
+    LogUtils.v(() => 'sendConnect connected success');
     return true;
   }
 

--- a/packages/0xchat-core/lib/src/account/account.dart
+++ b/packages/0xchat-core/lib/src/account/account.dart
@@ -37,6 +37,11 @@ class Account {
   RemoteSignerConnection? tempRemoteConnection;
 
   Map<String, Completer<NIP46CommandResult>> resultCompleters = {};
+  // Deadline of each pending remote signer command, keyed like resultCompleters.
+  Map<String, Timer> nip46CommandTimers = {};
+  // Connection status listener of the current remote signer connection, kept so
+  // that a new connection can replace it instead of stacking listeners up.
+  ConnectStatusCallBack? nip46ConnectStatusListener;
   NIP46CommandResultCallback? nip46commandResultCallback;
   NIP46ConnectionStatusCallback? nip46connectionStatusCallback;
 
@@ -326,6 +331,7 @@ class Account {
   }
 
   Future<void> logout() async {
+    resetNIP46State();
     NotificationHelper.sharedInstance.logout();
     await Connect.sharedInstance.closeAllConnects();
     Contacts.sharedInstance.allContacts.clear();

--- a/packages/base_framework/ox_common/lib/utils/ox_userinfo_manager.dart
+++ b/packages/base_framework/ox_common/lib/utils/ox_userinfo_manager.dart
@@ -74,7 +74,11 @@ class OXUserInfoManager {
 
   Future initDB(String pubkey) async {
     if(pubkey.isEmpty) return;
-    await logout(needObserver: false);
+    // Keep the stored pubkey. It is the only pointer back to the account that
+    // is logged in right now, and the login this call prepares can still fail
+    // or never finish - clearing it here is what used to leave the app looking
+    // like a fresh install after a failed 'add account'.
+    await logout(needObserver: false, clearPersistedPubkey: false);
     String dbpath = pubkey + ".db2";
     bool exists = await DB.sharedInstance.databaseExists(dbpath);
     if (exists) {
@@ -303,42 +307,53 @@ class OXUserInfoManager {
 
   Future<void> switchAccount(String selectedPubKey) async {
     String currentUserPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
-    await logout(needObserver: false);
+    await logout(needObserver: false, clearPersistedPubkey: false);
     await OXCacheManager.defaultOXCacheManager.saveForeverData(StorageKeyTool.KEY_PUBKEY, selectedPubKey);
     await OXUserInfoManager.sharedInstance.initLocalData();
     if (currentUserInfo == null) {
-      Map<String, MultipleUserModel> currentUserMap = await UserConfigTool.getAllUser();
-      if (currentUserMap.isNotEmpty) {
-        await UserConfigTool.deleteUser(currentUserMap, selectedPubKey);
-      }
-      await OXCacheManager.defaultOXCacheManager.saveForeverData(StorageKeyTool.KEY_PUBKEY, currentUserPubKey);
-      await OXUserInfoManager.sharedInstance.initLocalData();
+      // The selected account could not be opened. Put the previous one back
+      // instead of dropping the user into a logged out app, and leave the
+      // account list alone: a failed switch must never remove an account.
+      await restoreAccount(currentUserPubKey);
     }
     for (OXUserInfoObserver observer in _observers) {
       observer.didSwitchUser(currentUserInfo);
     }
   }
 
-  Future<UserDBISAR?> handleSwitchFailures(UserDBISAR? userDB, String currentUserPubKey) async {
-    if (userDB == null && currentUserPubKey.isNotEmpty) {
-      //In the case of failing to add a new account while already logged in, implement the logic to re-login to the current account.
-      await OXUserInfoManager.sharedInstance.initDB(currentUserPubKey);
-      userDB = await Account.sharedInstance.loginWithPubKeyAndPassword(currentUserPubKey);
+  /// Logs [pubkey] back in after a login attempt failed.
+  ///
+  /// Logging into another account tears the current session down before the new
+  /// one is known to work (see [initDB]), so every failure path has to put the
+  /// previous account back. No account is ever removed from the local account
+  /// list here: a lost session is recoverable, a deleted account is not.
+  Future<bool> restoreAccount(String pubkey) async {
+    if (pubkey.isEmpty) return false;
+    // Nothing was torn down, the account is still the one running. Reloading it
+    // here would drop its relay connections for no reason.
+    if (currentUserInfo?.pubKey == pubkey) return true;
+    try {
+      await OXCacheManager.defaultOXCacheManager.saveForeverData(StorageKeyTool.KEY_PUBKEY, pubkey);
+      await initLocalData();
+    } catch (error, stack) {
+      LogUtil.e('restoreAccount failed: $error\r\n$stack');
     }
-    return userDB;
+    return currentUserInfo?.pubKey == pubkey;
   }
 
-  Future logout({bool needObserver = true}) async {
+  Future logout({bool needObserver = true, bool clearPersistedPubkey = true}) async {
     if (OXUserInfoManager.sharedInstance.currentUserInfo == null) {
       return;
     }
     await Account.sharedInstance.logout();
-    resetData(needObserver: needObserver);
+    resetData(needObserver: needObserver, clearPersistedPubkey: clearPersistedPubkey);
   }
 
-  void resetData({bool needObserver = true}) {
+  void resetData({bool needObserver = true, bool clearPersistedPubkey = true}) {
     signatureVerifyFailed = false;
-    OXCacheManager.defaultOXCacheManager.saveForeverData(StorageKeyTool.KEY_PUBKEY, null);
+    if (clearPersistedPubkey) {
+      OXCacheManager.defaultOXCacheManager.saveForeverData(StorageKeyTool.KEY_PUBKEY, null);
+    }
     currentUserInfo = null;
     _contactFinishFlags = {
       _ContactType.contacts: false,

--- a/packages/business_modules/ox_login/assets/locale/i18n_en.json
+++ b/packages/business_modules/ox_login/assets/locale/i18n_en.json
@@ -31,6 +31,7 @@
   "lets_go": "Let’s go!",
   "enter_account_key_login_hint": "Use nostr key or remote signer to login:",
   "private_key_regular_failed": "Private Key regular failed",
+  "remote_signer_connect_failed": "Could not connect to the remote signer. Your account was not changed, please check the signer and try again.",
   "pub_key_regular_failed": "Pub Key regular failed",
   "str_not_installed_amber": "You have not installed Amber",
   "str_nesc_invalid_hint": "The NSEC you entered is invalid. Please enter it again.",

--- a/packages/business_modules/ox_login/assets/locale/i18n_zh.json
+++ b/packages/business_modules/ox_login/assets/locale/i18n_zh.json
@@ -31,6 +31,7 @@
   "lets_go": "让我们出发吧!",
   "enter_account_key_login_hint": "请输入您的密钥或远程签名URL",
   "private_key_regular_failed": "私钥规则检验失败",
+  "remote_signer_connect_failed": "无法连接到远程签名器，当前账号未发生变化，请检查签名器后重试。",
   "pub_key_regular_failed": "公钥规则检验失败",
   "str_not_installed_amber": "您尚未安装Amber",
   "str_nesc_invalid_hint": "您输入的NSEC无效，请重新输入",

--- a/packages/business_modules/ox_login/assets/locale/i18n_zh_tw.json
+++ b/packages/business_modules/ox_login/assets/locale/i18n_zh_tw.json
@@ -28,6 +28,7 @@
   "lets_go": "讓我們出發吧！",
   "enter_account_key_login_hint": "請輸入密鑰或URL以登入：",
   "private_key_regular_failed": "私鑰常規失敗",
+  "remote_signer_connect_failed": "無法連線到遠端簽名器，目前帳號未變更，請檢查簽名器後再試一次。",
   "pub_key_regular_failed": "公鑰常規失敗",
   "str_not_installed_amber": "您尚未安裝 Amber",
   "str_nesc_invalid_hint": "您輸入的NSEC無效，請重新輸入。",

--- a/packages/business_modules/ox_login/lib/page/account_key_login_page.dart
+++ b/packages/business_modules/ox_login/lib/page/account_key_login_page.dart
@@ -38,6 +38,7 @@ class AccountKeyLoginPage extends StatefulWidget {
 class _AccountKeyLoginPageState extends State<AccountKeyLoginPage> {
   TextEditingController _accountKeyEditingController = new TextEditingController();
   bool _isShowLoginBtn = false;
+  bool _isLoggingIn = false;
   String _accountKeyInput = '';
 
   @override
@@ -175,35 +176,61 @@ class _AccountKeyLoginPageState extends State<AccountKeyLoginPage> {
   }
 
   void _nescLogin() async {
-    await OXLoading.show();
-    String pubkey = "";
-    UserDBISAR? userDB;
-    String currentUserPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
-    if (_accountKeyInput.startsWith('bunker://')){
-      await OXLoading.dismiss();
+    if (_isLoggingIn) return;
+    final bool isRemoteSigner = _accountKeyInput.startsWith('bunker://');
+    if (isRemoteSigner) {
       bool result = await NIP46StatusNotifier.remoteSignerTips(Localized.text('ox_login.wait_link_service'));
-      if(!result) return;
-      await OXLoading.show();
-      pubkey = await Account.getPublicKeyWithNIP46URI(_accountKeyInput);
-      await OXUserInfoManager.sharedInstance.initDB(pubkey);
-      userDB = await Account.sharedInstance.loginWithNip46URI(_accountKeyInput);
-    } else {
-      pubkey = Account.getPublicKey(_accountKeyInput);
-      await OXUserInfoManager.sharedInstance.initDB(pubkey);
-      userDB = await Account.sharedInstance.loginWithPriKey(_accountKeyInput);
+      if (!result) return;
     }
-    userDB = await OXUserInfoManager.sharedInstance.handleSwitchFailures(userDB, currentUserPubKey);
+
+    _isLoggingIn = true;
+    await OXLoading.show();
+    // Logging in tears the running session down before the new account is
+    // known to work, so remember which account has to come back if it fails.
+    final String previousPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
+    UserDBISAR? userDB;
+    try {
+      if (isRemoteSigner) {
+        String pubkey = await Account.getPublicKeyWithNIP46URI(_accountKeyInput);
+        if (pubkey.isNotEmpty) {
+          await OXUserInfoManager.sharedInstance.initDB(pubkey);
+          userDB = await Account.sharedInstance.loginWithNip46URI(_accountKeyInput);
+        }
+      } else {
+        String pubkey = Account.getPublicKey(_accountKeyInput);
+        await OXUserInfoManager.sharedInstance.initDB(pubkey);
+        userDB = await Account.sharedInstance.loginWithPriKey(_accountKeyInput);
+      }
+    } catch (error, stack) {
+      LogUtil.e('login failed: $error\r\n$stack');
+      userDB = null;
+    }
+
     if (userDB == null) {
-      CommonToast.instance.show(context, Localized.text('ox_login.private_key_regular_failed'));
+      // Put the account that was logged in back exactly as it was. A failed
+      // login must never cost the user the account they already had.
+      await OXUserInfoManager.sharedInstance.restoreAccount(previousPubKey);
+      _isLoggingIn = false;
+      await OXLoading.dismiss();
+      if (!mounted) return;
+      CommonToast.instance.show(
+        context,
+        Localized.text(isRemoteSigner
+            ? 'ox_login.remote_signer_connect_failed'
+            : 'ox_login.private_key_regular_failed'),
+      );
       return;
     }
+
     Account.sharedInstance.reloadProfileFromRelay(userDB.pubKey).then((value) {
       LogUtil.e('Michael:---reloadProfileFromRelay--name = ${value.name}; pic =${value.picture}}');
       UserConfigTool.saveUser(value);
       UserConfigTool.updateSettingFromDB(value.settings);
     });
     OXUserInfoManager.sharedInstance.loginSuccess(userDB);
+    _isLoggingIn = false;
     await OXLoading.dismiss();
+    if (!mounted) return;
     OXNavigator.popToRoot(context);
   }
 }

--- a/packages/business_modules/ox_login/lib/page/login_page.dart
+++ b/packages/business_modules/ox_login/lib/page/login_page.dart
@@ -6,6 +6,7 @@ import 'package:chatcore/chat-core.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_core_dart/nostr.dart';
 import 'package:ox_common/const/common_constant.dart';
+import 'package:ox_common/log_util.dart';
 // ox_common
 import 'package:ox_common/navigator/navigator.dart';
 import 'package:ox_common/utils/adapt.dart';
@@ -281,15 +282,27 @@ class _LoginPageState extends State<LoginPage> {
   }
 
   void loginWithNostrConnect(String loginQRCodeUrl)async{
-    String pubkey = "";
+    // Logging in tears the running session down before the new account is
+    // known to work, so remember which account has to come back if it fails.
+    final String previousPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
     UserDBISAR? userDB;
-    String currentUserPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
-    pubkey = await Account.getPublicKeyWithNIP46URI(loginQRCodeUrl);
-    await OXUserInfoManager.sharedInstance.initDB(pubkey);
-    userDB = await Account.sharedInstance.loginWithNip46URI(loginQRCodeUrl);
-    userDB = await OXUserInfoManager.sharedInstance.handleSwitchFailures(userDB, currentUserPubKey);
+    try {
+      String pubkey = await Account.getPublicKeyWithNIP46URI(loginQRCodeUrl);
+      if (pubkey.isNotEmpty) {
+        await OXUserInfoManager.sharedInstance.initDB(pubkey);
+        userDB = await Account.sharedInstance.loginWithNip46URI(loginQRCodeUrl);
+      }
+    } catch (error, stack) {
+      LogUtil.e('login with nostr connect failed: $error\r\n$stack');
+      userDB = null;
+    }
+
     if (userDB == null) {
-      CommonToast.instance.show(context, Localized.text('ox_login.private_key_regular_failed'));
+      // Put the account that was logged in back exactly as it was. A failed
+      // login must never cost the user the account they already had.
+      await OXUserInfoManager.sharedInstance.restoreAccount(previousPubKey);
+      if (!mounted) return;
+      CommonToast.instance.show(context, Localized.text('ox_login.remote_signer_connect_failed'));
       return;
     }
     Account.sharedInstance.reloadProfileFromRelay(userDB.pubKey).then((value) {
@@ -298,6 +311,7 @@ class _LoginPageState extends State<LoginPage> {
     });
 
     OXUserInfoManager.sharedInstance.loginSuccess(userDB);
+    if (!mounted) return;
     OXNavigator.popToRoot(context);
   }
 
@@ -342,11 +356,21 @@ class _LoginPageState extends State<LoginPage> {
     if (signature.startsWith('npub')) {
       decodeSignature = UserDBISAR.decodePubkey(signature) ?? '';
     }
-    String currentUserPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
-    await OXUserInfoManager.sharedInstance.initDB(decodeSignature);
-    UserDBISAR? userDB = await Account.sharedInstance.loginWithPubKey(decodeSignature, SignerApplication.androidSigner);
-    userDB = await OXUserInfoManager.sharedInstance.handleSwitchFailures(userDB, currentUserPubKey);
+    // Logging in tears the running session down before the new account is
+    // known to work, so remember which account has to come back if it fails.
+    final String previousPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
+    UserDBISAR? userDB;
+    try {
+      await OXUserInfoManager.sharedInstance.initDB(decodeSignature);
+      userDB = await Account.sharedInstance.loginWithPubKey(decodeSignature, SignerApplication.androidSigner);
+    } catch (error, stack) {
+      LogUtil.e('login with external signer failed: $error\r\n$stack');
+      userDB = null;
+    }
     if (userDB == null) {
+      // Put the account that was logged in back exactly as it was. A failed
+      // login must never cost the user the account they already had.
+      await OXUserInfoManager.sharedInstance.restoreAccount(previousPubKey);
       await OXLoading.dismiss();
       if (mounted) {
         CommonToast.instance.show(context, Localized.text('ox_login.pub_key_regular_failed'));

--- a/packages/business_modules/ox_login/lib/page/login_with_qrcode_page.dart
+++ b/packages/business_modules/ox_login/lib/page/login_with_qrcode_page.dart
@@ -221,18 +221,29 @@ class _LoginWithQRCodePageState extends BasePageState<LoginWithQRCodePage> {
   }
 
   Future<void> _loginWithNip46() async {
-    String pubkey = "";
-    UserDBISAR? userDB;
-    String currentUserPubKey =
+    // Logging in tears the running session down before the new account is
+    // known to work, so remember which account has to come back if it fails.
+    final String previousPubKey =
         OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
-    pubkey = await Account.getPublicKeyWithNIP46URI(_loginQRCodeUrl);
-    await OXUserInfoManager.sharedInstance.initDB(pubkey);
-    userDB = await Account.sharedInstance.loginWithNip46URI(_loginQRCodeUrl);
-    userDB = await OXUserInfoManager.sharedInstance
-        .handleSwitchFailures(userDB, currentUserPubKey);
+    UserDBISAR? userDB;
+    try {
+      String pubkey = await Account.getPublicKeyWithNIP46URI(_loginQRCodeUrl);
+      if (pubkey.isNotEmpty) {
+        await OXUserInfoManager.sharedInstance.initDB(pubkey);
+        userDB = await Account.sharedInstance.loginWithNip46URI(_loginQRCodeUrl);
+      }
+    } catch (error, stack) {
+      LogUtil.e('login with QR code failed: $error\r\n$stack');
+      userDB = null;
+    }
+
     if (userDB == null) {
-      CommonToast.instance
-          .show(context, Localized.text('ox_login.private_key_regular_failed'));
+      // Put the account that was logged in back exactly as it was. A failed
+      // login must never cost the user the account they already had.
+      await OXUserInfoManager.sharedInstance.restoreAccount(previousPubKey);
+      if (!mounted) return;
+      CommonToast.instance.show(
+          context, Localized.text('ox_login.remote_signer_connect_failed'));
       return;
     }
     Account.sharedInstance.reloadProfileFromRelay(userDB.pubKey).then((value) {
@@ -241,6 +252,7 @@ class _LoginWithQRCodePageState extends BasePageState<LoginWithQRCodePage> {
     });
 
     OXUserInfoManager.sharedInstance.loginSuccess(userDB);
+    if (!mounted) return;
     OXNavigator.popToRoot(context);
   }
 

--- a/packages/business_modules/ox_login/lib/page/save_account_page.dart
+++ b/packages/business_modules/ox_login/lib/page/save_account_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 // common
+import 'package:ox_common/log_util.dart';
 import 'package:ox_common/navigator/navigator.dart';
 import 'package:ox_common/utils/adapt.dart';
 import 'package:ox_common/utils/theme_color.dart';
@@ -9,6 +10,7 @@ import 'package:ox_common/utils/ox_userinfo_manager.dart';
 import 'package:ox_common/widgets/common_appbar.dart';
 import 'package:ox_common/widgets/common_image.dart';
 import 'package:ox_common/widgets/common_loading.dart';
+import 'package:ox_common/widgets/common_toast.dart';
 
 import 'package:ox_localizable/ox_localizable.dart';
 import 'package:chatcore/chat-core.dart';
@@ -277,15 +279,30 @@ class _SaveAccountPageState extends State<SaveAccountPage>
 
   void _login() async {
     await OXLoading.show();
-    await OXUserInfoManager.sharedInstance.initDB(widget.keychain.public);
-    UserDBISAR userDB = await Account.newAccount(user: widget.keychain);
-    userDB = await Account.sharedInstance.loginWithPriKey(widget.keychain.private) ?? userDB;
-    userDB.name = widget.userName;
-    userDB.about = widget.userAbout;
-    userDB.dns = widget.userDns;
-    Account.sharedInstance.updateProfile(userDB);
-    await OXUserInfoManager.sharedInstance.loginSuccess(userDB);
+    // Creating the account tears the running session down before the new
+    // account exists, so remember which account has to come back if it fails.
+    final String previousPubKey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey ?? '';
+    try {
+      await OXUserInfoManager.sharedInstance.initDB(widget.keychain.public);
+      UserDBISAR userDB = await Account.newAccount(user: widget.keychain);
+      userDB = await Account.sharedInstance.loginWithPriKey(widget.keychain.private) ?? userDB;
+      userDB.name = widget.userName;
+      userDB.about = widget.userAbout;
+      userDB.dns = widget.userDns;
+      Account.sharedInstance.updateProfile(userDB);
+      await OXUserInfoManager.sharedInstance.loginSuccess(userDB);
+    } catch (error, stack) {
+      LogUtil.e('create account failed: $error\r\n$stack');
+      // Put the account that was logged in back exactly as it was. A failed
+      // account creation must never cost the user the account they had.
+      await OXUserInfoManager.sharedInstance.restoreAccount(previousPubKey);
+      await OXLoading.dismiss();
+      if (!mounted) return;
+      CommonToast.instance.show(context, Localized.text('ox_login.private_key_regular_failed'));
+      return;
+    }
     await OXLoading.dismiss();
+    if (!mounted) return;
     OXNavigator.popToRoot(context);
   }
 

--- a/test/ox_userinfo_manager_test.dart
+++ b/test/ox_userinfo_manager_test.dart
@@ -1,0 +1,41 @@
+// Regression test for https://github.com/0xchat-app/0xchat-app-main/issues/61.
+//
+// Adding another account closes the running session before the new login is
+// known to work, and the stored pubkey is the only pointer back to the account
+// that is logged in. Clearing it during that teardown is what left the app
+// looking like a fresh install when the second login never finished.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ox_cache_manager/ox_cache_manager.dart';
+import 'package:ox_common/utils/ox_userinfo_manager.dart';
+import 'package:ox_common/utils/storage_key_tool.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const String loggedInPubkey = 'b1a2c3d4e5f60718293a4b5c6d7e8f90';
+
+  Future<dynamic> storedPubkey() =>
+      OXCacheManager.defaultOXCacheManager.getForeverData(StorageKeyTool.KEY_PUBKEY);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await OXCacheManager.defaultOXCacheManager
+        .saveForeverData(StorageKeyTool.KEY_PUBKEY, loggedInPubkey);
+  });
+
+  test('closing the session to prepare another login keeps the stored account',
+      () async {
+    OXUserInfoManager.sharedInstance
+        .resetData(needObserver: false, clearPersistedPubkey: false);
+
+    expect(await storedPubkey(), loggedInPubkey);
+  });
+
+  test('logging out clears the stored account', () async {
+    OXUserInfoManager.sharedInstance.resetData(needObserver: false);
+
+    expect(await storedPubkey(), isNull);
+  });
+}


### PR DESCRIPTION
Fixes #61, the most damaging open issue: adding a second account with a `bunker://` URI hung forever and, after a restart, left the app with no account logged in at all.

Two independent defects, per the commit message: nothing bounded the NIP-46 waits (`connectToRemoteSigner()` only completed on a relay *status change*, which never arrives when the relay is already connected — exactly the case when adding a second account on a relay the first one uses), and the failure path tore down stored accounts instead of leaving the existing session alone.

**Overlaps with the NIP-46 half of the SOCKS proxy PR.** That one adds plain `.timeout()` calls to the same three futures; this branch supersedes them with the deeper fix that also detects the already-connected relay. Merge this one and drop the timeout hunks there, keeping only its proxy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)