### PR TITLE
fix: correct the SOCKS proxy address type

### DIFF
--- a/lib/http_overrides.dart
+++ b/lib/http_overrides.dart
@@ -87,7 +87,7 @@ class OXHttpOverrides extends HttpOverrides {
     if (proxy != null) {
       final client = await SocksTCPClient.connect(
         [proxy],
-        InternetAddress(uri.host, type: InternetAddressType.unix),
+        InternetAddress(uri.host, type: InternetAddressType.any),
         uriPort,
       );
 

--- a/packages/0xchat-core/lib/src/account/account+nip46.dart
+++ b/packages/0xchat-core/lib/src/account/account+nip46.dart
@@ -90,7 +90,13 @@ extension AccountNIP46 on Account {
     Completer<NIP46CommandResult> completer = Completer<NIP46CommandResult>();
     String secret = tempRemoteConnection!.secret!;
     resultCompleters[secret] = completer;
-    await completer.future;
+    await completer.future.timeout(
+      const Duration(seconds: 60),
+      onTimeout: () {
+        resultCompleters.remove(secret);
+        throw TimeoutException('Waiting for nostrconnect approval timed out');
+      },
+    );
     currentRemoteConnection = tempRemoteConnection;
     String? pubkey = await sendGetPubicKey();
     if (pubkey != null) {
@@ -165,7 +171,10 @@ extension AccountNIP46 on Account {
 
     await Connect.sharedInstance
         .connectRelays(remoteSignerConnection.relays, relayKind: RelayKind.remoteSigner);
-    return completer.future;
+    return completer.future.timeout(
+      const Duration(seconds: 30),
+      onTimeout: () => OKEvent(uri, false, 'Remote signer relay connection timed out'),
+    );
   }
 
   Future<String?> sendGetPubicKey() async {
@@ -237,7 +246,13 @@ extension AccountNIP46 on Account {
     } else {
       Connect.sharedInstance.sendEvent(event, toRelays: currentRemoteConnection!.relays);
     }
-    return completer.future;
+    return completer.future.timeout(
+      const Duration(seconds: 30),
+      onTimeout: () {
+        resultCompleters.remove(id);
+        throw TimeoutException('Remote signer did not respond in time');
+      },
+    );
   }
 
   Future<bool> sendConnect() async {


### PR DESCRIPTION
`lib/http_overrides.dart` passed `InternetAddressType.unix` — a Unix domain socket — as the target address type for what is a TCP connection to a hostname. Wrong on its face, and it can break HTTP/WS traffic routed through a SOCKS proxy. Relevant to the Tor path this app leans on.

**Merge note:** this branch also adds `.timeout()` calls to three futures in `account+nip46.dart`. The #61 branch rewrites the same code more thoroughly, including the already-connected-relay case that is the actual cause of the hang. Take the proxy fix from here and let the other branch own the NIP-46 changes, rather than merging both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)