### PR TITLE
fix: stop notifying the user about their own messages

### DIFF
--- a/packages/0xchat-core/doc/nofitications.md
+++ b/packages/0xchat-core/doc/nofitications.md
@@ -39,10 +39,45 @@ The 'content' is encrypted using the NIP04 protocol. The decrypted content is as
     "deviceId": "<device token>",
     "relays": "<list of relays for the push server to subscribe to>",
     "#e": "<list of groups to be notified about>",
+    "exclude_authors": "<list of pubkeys whose events must never be pushed>",
 }
 
 ```
 Upon receiving the encrypted message of 'kind' 22456, the push server decrypts it to obtain the subscription information (kinds, #e, #p) and the specified 'relays' to listen to. It then sends notifications to the device identified by the 'deviceId', using both APNs and FCM services.
+
+### Excluding the subscriber's own events
+
+A subscription matches events the subscriber published themselves. A channel
+message they posted carries the channel's 'e' tag, and NIP-17 gift wraps a copy
+of every outgoing message to the sender's own pubkey so that their other devices
+stay in sync - that copy is p-tagged with the sender's pubkey and is therefore
+indistinguishable from a real incoming message. Without a filter the subscriber
+is notified that they "received a private message" for a message they just sent.
+
+'exclude_authors' carries the subscriber's own pubkey(s). The push server must
+drop any matched event signed by one of them before pushing it. The list travels
+inside the NIP-04 encrypted payload, so it reveals nothing to relays or to third
+parties.
+
+### Push payload
+
+The payload delivered to the device carries the rendered notification plus the
+data the client needs to decide what to do with it:
+
+```json
+{
+    "notification": {"title": "<title>", "body": "<body>"},
+    "data": {
+        "msgType": "<0 for a message, 1 for a call>",
+        "sender": "<pubkey that signed the event, when the server can see it>"
+    }
+}
+
+```
+'sender' lets the client drop a notification for its own message if it reaches a
+push server that does not yet honour 'exclude_authors'. It is omitted when the
+author is not visible to the server, and clients must treat an absent 'sender'
+as "unknown" rather than suppressing the notification.
 
 ### Heartbeat:
 

--- a/packages/0xchat-core/lib/src/account/notification.dart
+++ b/packages/0xchat-core/lib/src/account/notification.dart
@@ -111,8 +111,16 @@ class NotificationHelper {
     Completer<OKEvent> completer = Completer<OKEvent>();
     List<String> channels = Channels.sharedInstance.getAllUnMuteChannels();
     List<String> groups = RelayGroup.sharedInstance.getAllUnMuteGroups();
-    var authors = Contacts.sharedInstance.allContacts.keys.toList();
-    var ptags = [Account.sharedInstance.currentPubkey];
+    String selfPubkey = Account.sharedInstance.currentPubkey;
+
+    // Our own pubkey must never be an author we ask to be notified about.
+    // The contact list is built from the follow list, and following yourself is
+    // a common habit on Nostr, so without this filter the push server treats
+    // every event we publish as an incoming one and notifies us about the
+    // messages we just sent.
+    var authors =
+        Contacts.sharedInstance.allContacts.keys.where((author) => author != selfPubkey).toList();
+    var ptags = [selfPubkey];
     // List<SecretSessionDB> secretSessions =
     // Contacts.sharedInstance.secretSessionMap.values.toList();
     // for (var session in secretSessions) {
@@ -130,7 +138,15 @@ class NotificationHelper {
       'deviceId': deviceId,
       'relays': relays,
       '#e': [...channels, ...groups],
-      '#p': ptags
+      '#p': ptags,
+
+      // '#e' and '#p' keep matching events we signed ourselves: a channel
+      // message we posted carries the channel's 'e' tag, and NIP-17 gift wraps
+      // a copy of every outgoing message to our own pubkey so that our other
+      // devices stay in sync. Both look exactly like an incoming message from
+      // the outside, so the server is told which pubkeys are ours and drops
+      // anything they signed before pushing.
+      'exclude_authors': [selfPubkey],
     };
     Event event = await _encode(serverPubkey, jsonEncode(map), '');
     unSendNotification = event;

--- a/packages/base_framework/ox_common/lib/utils/ox_chat_binding.dart
+++ b/packages/base_framework/ox_common/lib/utils/ox_chat_binding.dart
@@ -232,6 +232,19 @@ class OXChatBinding {
     }
   }
 
+  /// A message we signed ourselves is never an incoming message, even when it
+  /// reaches this device over a relay subscription. NIP-17 gift wraps a copy of
+  /// every outgoing message to the sender's own pubkey so that their other
+  /// devices stay in sync, so a message we just sent - or one the same account
+  /// sent from another device - arrives on the very subscription that carries
+  /// real incoming messages. Those messages still update the session, which is
+  /// how multi-device sync works, but they must never raise an unread count or
+  /// a notification.
+  bool _isFromCurrentUser(MessageDBISAR messageDB) {
+    final myPubkey = OXUserInfoManager.sharedInstance.currentUserInfo?.pubKey;
+    return myPubkey != null && myPubkey.isNotEmpty && messageDB.sender == myPubkey;
+  }
+
   ChatSessionModelISAR? syncChatSessionTable(MessageDBISAR messageDB, {int? chatType}) {
     final userdb = OXUserInfoManager.sharedInstance.currentUserInfo;
     if ( userdb == null || userdb.pubKey.isEmpty) {
@@ -272,7 +285,7 @@ class OXChatBinding {
         tempModel.createTime = sessionModel.createTime;
         tempModel.messageType = sessionModel.messageType;
       }
-      if (!messageDB.read && messageDB.sender != OXUserInfoManager.sharedInstance.currentUserInfo!.pubKey) {
+      if (!messageDB.read && !_isFromCurrentUser(messageDB)) {
         tempModel.unreadCount = tempModel.unreadCount += 1;
         noticePromptToneCallBack(messageDB, tempModel.chatType);
       }
@@ -295,7 +308,7 @@ class OXChatBinding {
         sessionModel.avatar = groupDBDB.picture ?? '';
         sessionModel.chatName = groupDBDB.name;
       }
-      if (!messageDB.read && messageDB.sender != OXUserInfoManager.sharedInstance.currentUserInfo!.pubKey) {
+      if (!messageDB.read && !_isFromCurrentUser(messageDB)) {
         sessionModel.unreadCount = 1;
         noticePromptToneCallBack(messageDB, sessionModel.chatType);
       }
@@ -317,7 +330,7 @@ class OXChatBinding {
         tempModel.createTime = sessionModel.createTime;
         tempModel.messageType = sessionModel.messageType;
       }
-      if (messageDB.sender != OXUserInfoManager.sharedInstance.currentUserInfo!.pubKey) {
+      if (!_isFromCurrentUser(messageDB)) {
         if (!messageDB.read) {
           tempModel.unreadCount = tempModel.unreadCount += 1;
           if (tempModel.chatType == ChatType.chatStranger || tempModel.chatType == ChatType.chatSecretStranger) {
@@ -341,7 +354,7 @@ class OXChatBinding {
       if (chatType != null) {
         sessionModel.chatType = chatType;
       }
-      if (!messageDB.read && messageDB.sender != OXUserInfoManager.sharedInstance.currentUserInfo!.pubKey) {
+      if (!messageDB.read && !_isFromCurrentUser(messageDB)) {
         sessionModel.unreadCount = 1;
         if (sessionModel.chatType == ChatType.chatStranger || sessionModel.chatType == ChatType.chatSecretStranger) {
           unReadStrangerSessionCount += 1;
@@ -372,7 +385,8 @@ class OXChatBinding {
     String chatId = '';
     String otherUserPubkey = '';
     if (messageDB.sessionId.isEmpty) {
-      chatId = otherUserPubkey = messageDB.sender != OXUserInfoManager.sharedInstance.currentUserInfo!.pubKey ? messageDB.sender : messageDB.receiver;
+      chatId = otherUserPubkey =
+          !_isFromCurrentUser(messageDB) ? messageDB.sender : messageDB.receiver;
     } else {
       chatId = messageDB.sessionId;
       SecretSessionDBISAR? ssDB = Contacts.sharedInstance.secretSessionMap[messageDB.sessionId];

--- a/packages/base_framework/ox_push/lib/src/local_notification_manager.dart
+++ b/packages/base_framework/ox_push/lib/src/local_notification_manager.dart
@@ -101,6 +101,7 @@ class LocalNotificationManager {
     String showTitle = '';
     String showContent = '';
     String msgType = '0';
+    String sender = '';
     try {
       String result = utf8.decode(message);
       LogUtil.d("Push: LocalNotificationManager--onMessage--result=${result}");
@@ -109,9 +110,21 @@ class LocalNotificationManager {
       showTitle = jsonMap['notification']?['title'] ?? '';
       showContent = jsonMap['notification']?['body'] ?? 'default';
       msgType = jsonMap['data']?['msgType'] ?? '0';
+      sender = jsonMap['data']?['sender']?.toString() ?? '';
     } catch (e) {
       showContent = 'You’ve received a message ';
       print(e.toString());
+    }
+
+    // A message we sent is never an incoming message. NIP-17 gift wraps a copy
+    // of every outgoing message to our own pubkey so that our other devices
+    // stay in sync, and that copy reaches the push server looking exactly like
+    // a message somebody sent us. Suppress it only on an exact match: an empty
+    // sender means the payload carries no author, and a real message must never
+    // be swallowed because of it.
+    if (sender.isNotEmpty && OXUserInfoManager.sharedInstance.isCurrentUser(sender)) {
+      LogUtil.d('Push: LocalNotificationManager--onMessage--skipped our own message');
+      return;
     }
 
     if (msgType == PushMsgType.call.text) {


### PR DESCRIPTION
Fixes the notification half of #43, which the maintainer already acknowledged as a bug.

The push subscription the client registers matches events the client itself publishes: `authors` comes from the follow list and following your own pubkey is common (and "Import Follows" carries it in), NIP-17 gift-wraps a copy of every outgoing message to the sender so other devices stay in sync, and `#e` covers the user's own channels.

The other two topics in #43 are out of scope here — the contact-import question was answered, and the NIP-4 warning UX deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)