### PR TITLE
ci: build the Windows installer from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@
 # macOS artifacts are ad-hoc signed only (the Xcode project uses
 # CODE_SIGN_IDENTITY = "-"). Distributing outside of a "right click -> Open"
 # flow additionally needs a Developer ID certificate and notarisation.
+#
+# The Windows job emits both a portable zip and an Inno Setup installer built
+# from windows/packaging/oxchat.iss. The installer is unsigned, so SmartScreen
+# will warn on first run until an Authenticode certificate is wired in.
 
 name: Build & Package
 
@@ -180,7 +184,7 @@ jobs:
           if-no-files-found: error
 
   windows:
-    name: Windows (x64)
+    name: Windows (installer + zip)
     if: github.ref_type == 'tag' || inputs.platform == 'all' || inputs.platform == 'windows'
     # Pinned, not windows-latest: that label now resolves to the
     # windows-2025-vs2026 image, and flutter_tools 3.29.3 maps only Visual
@@ -202,6 +206,35 @@ jobs:
           $v = "${{ steps.setup.outputs.version_name }}"
           New-Item -ItemType Directory -Force dist | Out-Null
           Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath "dist/oxchat-$v-windows-x64.zip"
+
+      # The zip above is the portable download; this is the one that installs.
+      # Inno Setup 6 ships preinstalled on the windows runner images, so this
+      # needs no extra download - see windows/packaging/oxchat.iss for what the
+      # installer does.
+      - name: Build installer
+        shell: pwsh
+        run: |
+          $v = "${{ steps.setup.outputs.version_name }}"
+          $root = (Get-Location).Path
+
+          # The images put ISCC.exe on PATH, but that is an image detail rather
+          # than a promise, so fall back to the install location.
+          $iscc = (Get-Command ISCC.exe -ErrorAction SilentlyContinue).Source
+          if (-not $iscc) { $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" }
+          if (-not (Test-Path $iscc)) { throw "Inno Setup compiler not found - looked on PATH and at $iscc" }
+
+          & $iscc /Q `
+            "/DAppVersion=$v" `
+            "/DBuildDir=$root\build\windows\x64\runner\Release" `
+            "/DDistDir=$root\dist" `
+            "/DOutputName=oxchat-$v-windows-x64-setup" `
+            windows\packaging\oxchat.iss
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit code $LASTEXITCODE" }
+
+          # /Q silences ISCC, so confirm the artifact rather than trusting it.
+          $setup = "dist/oxchat-$v-windows-x64-setup.exe"
+          if (-not (Test-Path $setup)) { throw "$setup was not produced" }
+          "{0} ({1:N1} MB)" -f $setup, ((Get-Item $setup).Length / 1MB)
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ flutter build linux     # Linux
 flutter build windows   # Windows
 ```
 
+**4. Windows — build the installer**
+
+`flutter build windows` leaves a loose folder under `build/`. To produce the
+same `setup.exe` that CI attaches to releases, compile the
+[Inno Setup](https://jrsoftware.org/isinfo.php) script afterwards:
+
+```sh
+"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" windows\packaging\oxchat.iss
+```
+
+The installer is written to `dist/`. It installs per-user by default (no admin
+prompt, with an all-users option on the first page), creates a Start Menu
+shortcut and an optional desktop shortcut, and registers an uninstaller.
+
 **Build and test with Docker (Linux only)**
 
 Use the included Dockerfile to build and test in a clean container without

--- a/windows/packaging/oxchat.iss
+++ b/windows/packaging/oxchat.iss
@@ -1,0 +1,109 @@
+; Inno Setup script for the 0xchat Windows desktop build.
+;
+; Until now the .exe attached to releases was built outside this repository, so
+; the missing Start Menu entry reported in issue #54 could not be traced or
+; fixed from source. This script is compiled by the Windows job in
+; .github/workflows/build.yml, which makes the released installer reproducible.
+;
+; Everything build-specific arrives as a /D define, so the script carries no
+; assumptions about the machine compiling it. The defaults below resolve
+; relative to this file, so a local run from a checkout needs no arguments:
+;
+;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" windows\packaging\oxchat.iss
+;
+; and CI overrides them with absolute paths and the release version:
+;
+;   ISCC.exe /DAppVersion=1.5.5 /DBuildDir=... /DDistDir=... /DOutputName=...
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+; Output of `flutter build windows --release`.
+#ifndef BuildDir
+  #define BuildDir "..\..\build\windows\x64\runner\Release"
+#endif
+
+#ifndef DistDir
+  #define DistDir "..\..\dist"
+#endif
+
+#ifndef OutputName
+  #define OutputName "oxchat-" + AppVersion + "-windows-x64-setup"
+#endif
+
+#define AppName "0xchat"
+; BINARY_NAME in windows/CMakeLists.txt.
+#define AppExeName "oxchat_app_main.exe"
+#define RepoUrl "https://github.com/0xchat-app/0xchat-app-main"
+
+[Setup]
+; Never change AppId: it is how Windows recognises an existing installation, so
+; a new value would turn every upgrade into a second, parallel install.
+AppId={{80FF85C0-6043-4827-B024-6B57A0C07358}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppName}
+AppPublisherURL={#RepoUrl}
+AppSupportURL={#RepoUrl}/issues
+AppUpdatesURL={#RepoUrl}/releases
+AppCopyright=Copyright (C) 2023 0xchat
+
+; The binary is named oxchat_app_main, so without these the uninstall entry
+; would read that instead of the product name.
+UninstallDisplayName={#AppName}
+UninstallDisplayIcon={app}\{#AppExeName}
+
+DefaultDirName={autopf}\{#AppName}
+; Nothing uses {group}: the shortcut goes straight into the Programs list
+; rather than into a folder holding a single item, so the page asking where to
+; put that folder has nothing to decide.
+DisableProgramGroupPage=yes
+
+LicenseFile=..\..\LICENSE
+SetupIconFile=..\runner\resources\app_icon.ico
+OutputDir={#DistDir}
+OutputBaseFilename={#OutputName}
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+
+; The Flutter runner is 64-bit only.
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+; Flutter supports Windows 10 1809 and later.
+MinVersion=10.0.17763
+
+; Default to a per-user install under %LOCALAPPDATA%, which needs no UAC
+; prompt, while still letting the user pick an all-users install on the first
+; wizard page. Either way the shortcut lands in the matching Start Menu.
+; Upgrades reuse the scope of the existing install and skip the question.
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+
+; Ask the Restart Manager to close a running 0xchat rather than failing to
+; overwrite its files mid-upgrade.
+CloseApplications=yes
+RestartApplications=no
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#BuildDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+; The fix for issue #54: {autoprograms} is the Start Menu of whichever scope
+; the install ran in, so the app is searchable straight after installing.
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+; The other half of issue #54: offer to start the app when setup finishes.
+; runasoriginaluser keeps 0xchat from inheriting the elevated token when the
+; user chose an all-users install.
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent runasoriginaluser


### PR DESCRIPTION
Fixes #54, where installing 0xchat on Windows left no Start Menu entry and no way to launch it. Nothing in this repository could have fixed that: the `.exe` on releases is built outside it, and the tree holds no Inno Setup, NSIS or MSIX configuration at all.

Adds `windows/packaging/oxchat.iss` and compiles it in the Windows job alongside the portable zip, so the released installer is finally reproducible from source. It registers a Start Menu shortcut, an optional desktop shortcut and an uninstaller, and offers to launch on finish. Per-user under `%LOCALAPPDATA%` by default so no UAC prompt appears, with an all-users option; upgrades match on a fixed AppId and reuse the previous scope.

**Merge note:** edits `.github/workflows/build.yml` — see the conflict note on the other CI branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)