### PR TITLE
fix: stop the app aborting at launch without an audio backend

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,19 @@ dependency_overrides:
       path: packages/url_launcher/url_launcher_linux
   nostr_core_dart:
     path: packages/nostr-dart
+  # Upstream builds the WebRTC peer connection factory inside the plugin
+  # constructor, which runs during plugin registration - before any Dart code.
+  # On a machine with no usable audio backend the audio device module fails to
+  # initialise and WebRTC CHECK-fails, aborting the process at launch, so the
+  # app cannot start even for users who never place a call (issue #57, and
+  # upstream flutter-webrtc #1212 / #1477 / #2025, still open on main).
+  # This fork defers that construction to the first method channel call.
+  # Pinned to a commit, not a branch: a floating ref is what broke
+  # image_gallery_saver_plus.
+  flutter_webrtc:
+    git:
+      url: https://github.com/0xchat-app/flutter-webrtc.git
+      ref: b5f59c25a80cdb841b2c3ba55ee915ae57dbc63d
   # nostr_mls_package:
   #   path: packages/nostr-mls-package
   # Temporarily disabled to avoid bundling Rust code


### PR DESCRIPTION
Fixes #57. The Linux build aborts during startup on any machine where the WebRTC audio device module cannot initialise:

```
# Fatal error in: ../../media/engine/adm_helpers.cc, line 39
# Check failed: 0 == adm->Init() (0 vs. -1)
```

The cause is not in this repository. `flutter_webrtc` constructs `FlutterWebRTC` in its plugin constructor, and `FlutterWebRTCBase`'s constructor calls `CreateRTCPeerConnectionFactory()`, which initialises the ADM. That runs inside `fl_register_plugins()`, so the abort happens **before any Dart code executes** — deferring initialisation from `ox_calling` or `ox_common` is impossible, and a user who never places a call still cannot launch the app.

Upgrading does not help: flutter_webrtc `main` still creates the factory in that constructor. Upstream has had this open for years (flutter-webrtc #1212, #2025; #1477 closed by adding libpulse to a Snap). So the dependency points at a fork of the exact pinned version with the construction deferred to the first method channel call, pinned to a commit rather than a branch.

Fork: https://github.com/0xchat-app/flutter-webrtc/tree/lazy-adm-init

Verified in an `ubuntu:22.04` container with no PulseAudio server and no sound card, built from a clean tree so the fork is what pub actually resolves:

```
before:  # Failed to initialize the ADM.  ->  Aborted (core dumped)
after:   flutter: ✓ FRB initialized
         flutter: Instance of Tor created!
```

The trigger is broader than the issue title suggests — three container variants (libpulse present but no server, libpulse removed, ALSA null device) all abort identically, so headless servers, containers and CI runners are affected too. The fork carries the same change for Windows, whose plugin shares the constructor.

This commit was pushed to `ci/build-and-package-workflows` after #71 had already merged, so it needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)