### PR TITLE
fix: install libunwind-dev so the Linux job can resolve gstreamer

### DIFF
--- a/.github/actions/linux-build-deps/action.yml
+++ b/.github/actions/linux-build-deps/action.yml
@@ -1,0 +1,33 @@
+name: Linux build dependencies
+description: >-
+  apt packages the Flutter Linux build needs. Shared so the release build and
+  the weekly health check cannot drift apart.
+
+runs:
+  using: composite
+  steps:
+    # Mirrors the package list in the repo Dockerfile, plus libunwind-dev. The
+    # runner image ships an LLVM toolchain whose libunwind conflicts with the
+    # one libgstreamer1.0-dev depends on, so apt reports held broken packages
+    # unless libunwind-dev is requested in the same transaction. A clean
+    # ubuntu:22.04 container has no such conflict, which is why this only
+    # showed up on a real runner.
+    - shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          clang \
+          cmake \
+          ninja-build \
+          pkg-config \
+          file \
+          libgtk-3-dev \
+          libglu1-mesa \
+          libssl-dev \
+          libunwind-dev \
+          libgstreamer1.0-dev \
+          libgstreamer-plugins-base1.0-dev \
+          gstreamer1.0-plugins-base \
+          gstreamer1.0-plugins-good \
+          gstreamer1.0-plugins-bad \
+          gstreamer1.0-libav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,29 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Mirrors the package list in the repo Dockerfile, plus libunwind-dev.
-      # The runner image ships an LLVM toolchain whose libunwind conflicts with
-      # the one libgstreamer1.0-dev depends on, so apt reports held broken
-      # packages unless libunwind-dev is requested in the same transaction.
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            clang \
-            cmake \
-            ninja-build \
-            pkg-config \
-            file \
-            libgtk-3-dev \
-            libglu1-mesa \
-            libssl-dev \
-            libgstreamer1.0-dev \
-            libgstreamer-plugins-base1.0-dev \
-            libunwind-dev \
-            gstreamer1.0-plugins-base \
-            gstreamer1.0-plugins-good \
-            gstreamer1.0-plugins-bad \
-            gstreamer1.0-libav
+      - uses: ./.github/actions/linux-build-deps
 
       - id: setup
         uses: ./.github/actions/setup-flutter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Mirrors the package list in the repo Dockerfile.
+      # Mirrors the package list in the repo Dockerfile, plus libunwind-dev.
+      # The runner image ships an LLVM toolchain whose libunwind conflicts with
+      # the one libgstreamer1.0-dev depends on, so apt reports held broken
+      # packages unless libunwind-dev is requested in the same transaction.
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -156,6 +159,7 @@ jobs:
             libssl-dev \
             libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev \
+            libunwind-dev \
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-bad \

--- a/.github/workflows/weekly-build-check.yml
+++ b/.github/workflows/weekly-build-check.yml
@@ -1,0 +1,77 @@
+# Weekly answer to one question: does main still build?
+#
+# Not a packaging run - it produces no artifacts, touches no signing key and
+# never uploads to Play, so it cannot consume an Android version code. Linux
+# alone, because it is the cheapest runner that still compiles all of the Dart
+# and the Rust the `tor` package brings in; a break in shared code shows up
+# here without paying for four platforms.
+#
+# Nothing is built when main has not moved since the last successful check, so
+# a quiet week costs one API call.
+#
+# GitHub disables scheduled workflows after 60 days without repository
+# activity and emails the admins when it does. It also emails on a failed
+# scheduled run, which is how this reports a break.
+name: Weekly build check
+
+on:
+  schedule:
+    # Mondays, 02:00 UTC. Off-peak, so the run is not queued behind others.
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: weekly-build-check
+  cancel-in-progress: true
+
+jobs:
+  decide:
+    name: Has main moved?
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+    steps:
+      # Compares against the commit of the last *successful* check rather than
+      # a timestamp: if a check fails, the next run sees an older successful
+      # commit and tries again, so a break keeps being reported until it is
+      # fixed instead of being reported once and forgotten.
+      - name: Compare against the last successful check
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          last=$(curl -sf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/weekly-build-check.yml/runs?status=success&per_page=1" \
+            | python3 -c "import sys,json; r=json.load(sys.stdin).get('workflow_runs') or []; print(r[0]['head_sha'] if r else '')" ) || last=""
+
+          echo "current commit:        ${GITHUB_SHA}"
+          echo "last checked commit:   ${last:-none}"
+
+          if [ -n "$last" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "No new commits since the last successful check - skipping the build." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Linux (x64)
+    needs: decide
+    if: needs.decide.outputs.build == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/linux-build-deps
+
+      - uses: ./.github/actions/setup-flutter
+
+      # No artifact upload: the point is whether this command succeeds.
+      - name: Build
+        run: flutter build linux --release


### PR DESCRIPTION
The Linux job had never actually run on a GitHub runner. The branch-push test used to validate Windows only enabled that one platform, and no tag build has happened yet, so its first real run — dispatched today — failed in apt:

```
libgstreamer1.0-dev : Depends: libunwind-dev
E: Unable to correct problems, you have held broken packages.
```

The `ubuntu-22.04` image ships an LLVM toolchain whose libunwind packages conflict with the one `libgstreamer1.0-dev` wants, so apt cannot resolve it unless `libunwind-dev` is requested in the same transaction.

Worth recording why this was missed: the Linux build *was* verified locally, but in a clean `ubuntu:22.04` container built from this workflow's exact apt list. A bare container has no LLVM toolchain and therefore no conflict, so the container passed while the real runner cannot. Mirroring the package list was not enough — the runner image's own contents matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)