### PR TITLE
ci: cache Gradle and pub so builds stop starting from cold

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -48,12 +48,34 @@ runs:
         rustup --version
         cargo --version
 
+    # Pin the pub cache to one path on every runner. Windows would otherwise
+    # put it under %LOCALAPPDATA%, which the cache step below cannot express
+    # with a single path.
+    - name: Pin the pub cache location
+      shell: bash
+      run: echo "PUB_CACHE=$HOME/.pub-cache" >> "$GITHUB_ENV"
+
     - name: Install Flutter ${{ inputs.flutter-version }}
       uses: subosito/flutter-action@v2
       with:
         flutter-version: ${{ inputs.flutter-version }}
         channel: stable
         cache: true
+
+    # flutter-action caches the pub directory too, but its restore key never
+    # matched: three consecutive runs all logged "Cache not found" for
+    # flutter-pub-*, so every build re-fetched everything - including the
+    # ~100 MB flutter_webrtc fork clone the override pulls in. Cache it here
+    # with a key that is stable across runs, and a restore-keys prefix so a
+    # changed pubspec still starts from the last cache rather than nothing.
+    - name: Cache pub dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.pub-cache
+        key: pub-${{ runner.os }}-${{ inputs.flutter-version }}-${{ hashFiles('**/pubspec.yaml') }}
+        restore-keys: |
+          pub-${{ runner.os }}-${{ inputs.flutter-version }}-
+          pub-${{ runner.os }}-
 
     - name: Resolve dependencies
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,20 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      # Gradle downloads its dependencies and recompiles everything from cold
+      # on each run: bundleRelease measured 1399-1737s across three runs, while
+      # a warm local rebuild of the same target takes about a minute. Keyed on
+      # the build files so a dependency change invalidates it, with a prefix
+      # fallback so an unrelated edit still starts warm.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
       # cargokit (used by the `tor` dependency) builds the native library with
       # the exact NDK named by android.ndkVersion in android/app/build.gradle.
       - name: Install Android NDK


### PR DESCRIPTION
Two separate problems, measured rather than assumed.

**Gradle had no cache at all.** `bundleRelease` took 1704s, 1399s and 1737s across three consecutive runs, while a warm local rebuild of the same target finishes in about a minute — so nearly all of that is re-downloading dependencies and recompiling what has not changed.

**The pub cache looked handled but never restored.** `flutter-action` runs with `cache: true`, yet all three runs logged `Cache not found for input keys: flutter-pub-...`, so every build re-fetched the full dependency set — including the ~100 MB `flutter_webrtc` fork clone the override now pulls in. It is cached explicitly here with a key that is stable between runs, and `PUB_CACHE` is pinned first because Windows would otherwise keep it under `%LOCALAPPDATA%`, which no single cache path could cover.

Both use a `restore-keys` prefix, so changing a dependency degrades to warming from the previous cache instead of falling back to nothing.

Two things worth knowing when reviewing the effect:

- the benefit only shows on the *second* run — the first writes the cache
- caches are scoped to the branch that wrote them plus descendants, so the first build on `main` is what makes them available to every branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)