### PR TITLE
fix(ci): give Windows a native PUB_CACHE path so pub can resolve git deps

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -51,9 +51,21 @@ runs:
     # Pin the pub cache to one path on every runner. Windows would otherwise
     # put it under %LOCALAPPDATA%, which the cache step below cannot express
     # with a single path.
+    #
+    # The path has to be written in the form the *consumer* understands, not
+    # the form bash uses. Every later step runs Dart/Flutter as a native
+    # Windows process, but $HOME under Git Bash is POSIX (/c/Users/runneradmin),
+    # and pub cannot resolve that - it fails looking for its git cache at
+    # "c/Users/runneradmin/.pub-cache/git/cache/..." and reports the first git
+    # dependency as missing. Convert to a native path on Windows.
     - name: Pin the pub cache location
       shell: bash
-      run: echo "PUB_CACHE=$HOME/.pub-cache" >> "$GITHUB_ENV"
+      run: |
+        if [ "$RUNNER_OS" = Windows ]; then
+          echo "PUB_CACHE=$(cygpath -w "$HOME")\\.pub-cache" >> "$GITHUB_ENV"
+        else
+          echo "PUB_CACHE=$HOME/.pub-cache" >> "$GITHUB_ENV"
+        fi
 
     - name: Install Flutter ${{ inputs.flutter-version }}
       uses: subosito/flutter-action@v2
@@ -72,10 +84,10 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.pub-cache
-        key: pub-${{ runner.os }}-${{ inputs.flutter-version }}-${{ hashFiles('**/pubspec.yaml') }}
+        key: pub-v2-${{ runner.os }}-${{ inputs.flutter-version }}-${{ hashFiles('**/pubspec.yaml') }}
         restore-keys: |
-          pub-${{ runner.os }}-${{ inputs.flutter-version }}-
-          pub-${{ runner.os }}-
+          pub-v2-${{ runner.os }}-${{ inputs.flutter-version }}-
+          pub-v2-${{ runner.os }}-
 
     - name: Resolve dependencies
       shell: bash


### PR DESCRIPTION
Fixes #87.

The Windows job has been failing at `flutter pub get` since `e109322` (#85), so it never reaches the build:

```
Because ox_chat_project depends on flutter_webrtc from git which doesn't exist
(Could not find git ref 'b5f59c25...' (fatal: not a git repository:
 'c/Users/runneradmin/.pub-cache/git/cache/flutter-webrtc-06ca870...'))
version solving failed.
##[error]Process completed with exit code 69.
```

## Cause

The "Pin the pub cache location" step runs under bash, where `$HOME` on Windows is a POSIX path (`/c/Users/runneradmin`). It wrote `PUB_CACHE=/c/Users/runneradmin/.pub-cache` into `$GITHUB_ENV`, but every later step runs Dart/Flutter as a **native Windows process**, which cannot interpret that. Pub looked for its git cache under `c/Users/runneradmin/...` and reported the first git dependency as missing.

`flutter_webrtc` is just the first git dependency pub tries; the cause is not specific to that package. Linux and macOS were unaffected because `$HOME` is already a POSIX path there.

## Change

`.github/actions/setup-flutter/action.yml`:

- Convert the path with `cygpath -w` on Windows, so `PUB_CACHE=C:\Users\runneradmin\.pub-cache`. The non-Windows branch is untouched.
- Bump the cache key `pub-` → `pub-v2-` (key and both `restore-keys`). Any `pub-Windows-*` entry saved since `e109322` was populated against the malformed path, so fixing the path alone would keep restoring a poisoned cache.

The key bump also discards the warm pub cache on Linux and macOS for one run. That is the cost of not special-casing the prefix per OS, and it self-heals on the next build.

## Verification

[run 33037303516](https://github.com/0xchat-app/0xchat-app-main/actions/runs/33037303516/job/98402726539) — Windows green end to end, `windows` artifact 78.7 MB.

| Step | Before (`0d47622`) | After (`928160f`) |
|---|---|---|
| `setup-flutter` (contains `pub get`) | ❌ exit 69 after ~3.5 min | ✅ 4m31s |
| Build | never reached | ✅ 17m26s |
| Package | never reached | ✅ |
| Build installer | never reached | ✅ |
| Upload artifact | never reached | ✅ 78.7 MB |

macOS and Linux were verified green on `main` at `0d47622` just before this change ([macOS](https://github.com/0xchat-app/0xchat-app-main/actions/runs/32935386415), [Linux](https://github.com/0xchat-app/0xchat-app-main/actions/runs/32927958828)), confirming the regression was Windows-only. They have not been re-run against `928160f`; the only change affecting them is the cold cache.

Build, packaging and installer generation are all this verifies — nobody has installed or launched the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG)_