### PR TITLE
chore: bump to 1.5.6+109 for the next release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.5+107
+version: 1.5.6+109
 
 environment:
   sdk: ">=3.0.5 <4.0.0"


### PR DESCRIPTION
Prepares the version so a tag can actually produce a release. One line in `pubspec.yaml`: `1.5.5+107` → `1.5.6+109`.

Both halves had to move.

**Version name.** `1.5.5` already shipped — [v1.5.5-release](https://github.com/0xchat-app/0xchat-app-main/releases/tag/v1.5.5-release), 2026-03-11. `build.yml` fails a tag whose name disagrees with `pubspec.yaml`, so the tag has to be `v1.5.6-release` and pubspec has to say `1.5.6` to match. (The workflow parses `v1.5.6-release` → `1.5.6` via `${tag_version%%-release*}`, matching the existing tag convention.)

**Build number.** This is the Android `versionCode`, and Play rejects one that does not increase. `b26b080` recorded **109 as the first genuinely free code**, so `107` would be refused on upload — and that takes the release down with it, since `release` declares `needs: [android, linux, windows, macos, play]` with `!failure()`.

## Still required before tagging

`PLAY_SERVICE_ACCOUNT_JSON` must be set. On a tag the `play` job always runs, and its first step is:

```yaml
- name: Require the Play credential
  if: env.PLAY_SERVICE_ACCOUNT_JSON == ''
  run: |
    echo "::error::PLAY_SERVICE_ACCOUNT_JSON is not set."
    exit 1
```

There is no path that tags and skips Play. Without that secret the tag burns nothing on Play but produces no GitHub release either.

## Note on 109

I could not verify 109 is still free — `play-check.yml`, the read-only probe added in `edf18e3`, is listed under Actions but no longer exists anywhere in `main`'s tree, so it cannot be dispatched. 109 comes from `b26b080`'s commit message (2026-08-24) and the `play` job has not run successfully since, so it is very likely still free. If Play rejects it, bump again — a rejected upload does not consume the code.

Tagging is irreversible: it permanently consumes a version code and leaves a draft on Play's internal track. This PR deliberately stops short of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG)_