### PR TITLE
docs: record that commits must not be attributed to wcat7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Working notes for Claude Code
+
+## Commit attribution
+
+Commits must not be attributed to the `wcat7` / `water783` account.
+
+Git authorship is already correct — this environment commits as
+`Claude <noreply@anthropic.com>` — so nothing needs changing there.
+
+The account leaks in through **merge commits**: merging a PR through the
+GitHub API or web button authors the merge commit as whoever performed it.
+`e49c3d3` (PR #88) is an example, created by an agent-side merge.
+
+So: **do not merge pull requests.** Open the PR and leave the merge to a
+human, who can choose the identity it lands under.
+
+Note the limit of this rule. Every GitHub API action in an agent session —
+opening a PR, commenting on an issue, dispatching a workflow, pushing a tag —
+is recorded under the account backing the session token, which is currently
+`wcat7`. That is the session identity and cannot be switched from inside the
+session. Only the git commit author and the choice not to merge are under
+agent control; anything requiring a different actor has to be done by a human
+or by a session authenticated as a different account.


### PR DESCRIPTION
Adds a `CLAUDE.md` so the rule survives past this session.

## What was actually happening

Git authorship was never the problem — this environment already commits as `Claude <noreply@anthropic.com>`:

| Commit | Author |
|---|---|
| `928160f`, `a565e94` (written by the agent) | `Claude <noreply@anthropic.com>` |
| `e49c3d3` (PR #88 merge), `4ebc9f8` (PR #90 merge) | `water783 <…wcat7@…>` |

The account only appears on **merge commits**, which are authored by whoever presses merge. `e49c3d3` was an agent-side merge through the GitHub API.

## The rule

**Do not merge pull requests.** Open the PR and leave the merge to a human, who can choose the identity it lands under.

## What this rule cannot cover

Every GitHub API action in an agent session — opening a PR, commenting on an issue, dispatching a workflow, pushing a tag — is recorded under the account backing the session token, currently `wcat7`. That is the session identity and cannot be switched from inside the session. Only git commit authorship and the choice not to merge are under agent control.

Worth knowing before the release: **if the agent pushes `v1.5.6-release`, the tag's pusher will be `wcat7` too.** If that matters, the tag should be pushed by a human.

Per the rule this PR introduces, I am not merging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMp5EksxES6zd4pP28nkxG)_